### PR TITLE
Fix verbose ObjectResultExecutor logs in Development

### DIFF
--- a/src/PeanutVision.Api/appsettings.Development.json
+++ b/src/PeanutVision.Api/appsettings.Development.json
@@ -8,7 +8,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
-      "Microsoft.AspNetCore": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Development 환경에서 `Microsoft.AspNetCore` 로그 레벨을 `Information` → `Warning`으로 변경
- API 응답마다 익명 타입의 긴 제네릭 시그니처가 콘솔에 출력되던 문제 해결
- `ObjectResultExecutor`의 불필요한 verbose 로그 억제

## Test plan
- [x] Development 환경에서 acquisition 시작 시 `ObjectResultExecutor` 로그가 더 이상 출력되지 않는지 확인
- [x] 앱 자체 로그(`Default: Debug`)는 정상 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)