### PR TITLE
fix: Event Log UI overflow and message truncation

### DIFF
--- a/src/peanut-vision-ui/src/components/EventLog.tsx
+++ b/src/peanut-vision-ui/src/components/EventLog.tsx
@@ -1,16 +1,46 @@
+import { useEffect, useRef } from "react";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
+import StopCircleIcon from "@mui/icons-material/StopCircle";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import type { ChannelEvent } from "../api/types";
 
-const typeColor: Record<string, "info" | "warning" | "error" | "default"> = {
-  AcquisitionStarted: "info",
-  AcquisitionStopped: "info",
+const typeColor: Record<string, "success" | "warning" | "error" | "default"> = {
+  AcquisitionStarted: "success",
+  AcquisitionStopped: "default",
   FrameDropped: "warning",
   BufferUnavailable: "warning",
   AcquisitionError: "error",
+};
+
+const chipLabel: Record<string, string> = {
+  AcquisitionStarted: "START",
+  AcquisitionStopped: "STOP",
+  FrameDropped: "DROP",
+  BufferUnavailable: "BUF",
+  AcquisitionError: "ERROR",
+};
+
+const borderAccent: Record<string, string> = {
+  AcquisitionStarted: "success.main",
+  AcquisitionStopped: "text.disabled",
+  FrameDropped: "warning.main",
+  BufferUnavailable: "warning.main",
+  AcquisitionError: "error.main",
+};
+
+const typeIcon: Record<string, React.ReactElement> = {
+  AcquisitionStarted: <PlayCircleOutlineIcon sx={{ fontSize: 14 }} />,
+  AcquisitionStopped: <StopCircleIcon sx={{ fontSize: 14 }} />,
+  FrameDropped: <WarningAmberIcon sx={{ fontSize: 14 }} />,
+  BufferUnavailable: <WarningAmberIcon sx={{ fontSize: 14 }} />,
+  AcquisitionError: <ErrorOutlineIcon sx={{ fontSize: 14 }} />,
 };
 
 function formatTime(timestamp: string): string {
@@ -28,41 +58,97 @@ interface Props {
 }
 
 export default function EventLog({ events }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const threshold = 80;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    if (nearBottom) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [events]);
+
+  const reversed = events ? [...events].reverse() : [];
+
   return (
     <Card variant="outlined">
       <CardContent>
-        <Typography variant="subtitle2" gutterBottom>
-          Event Log
-        </Typography>
-        {events && events.length > 0 ? (
-          <Box sx={{ maxHeight: 300, overflowY: "auto" }}>
-            {events.map((evt, i) => (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 1,
+          }}
+        >
+          <Typography variant="subtitle2">Event Log</Typography>
+          {events && events.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              {events.length} events
+            </Typography>
+          )}
+        </Box>
+
+        {reversed.length > 0 ? (
+          <Box
+            ref={scrollRef}
+            sx={{
+              maxHeight: { xs: 240, sm: 320, md: "calc(100vh - 500px)" },
+              minHeight: 120,
+              overflowY: "auto",
+            }}
+          >
+            {reversed.map((evt, i) => (
               <Box
                 key={i}
                 sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  py: 0.5,
+                  pl: 1,
+                  pr: 0.5,
+                  py: 0.75,
+                  borderLeft: "3px solid",
+                  borderColor: borderAccent[evt.type] ?? "divider",
                   borderBottom: "1px solid",
-                  borderColor: "divider",
+                  borderBottomColor: "divider",
                   "&:last-child": { borderBottom: "none" },
+                  mb: 0.25,
                 }}
               >
+                {/* Row 1: chip + timestamp */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    mb: 0.25,
+                  }}
+                >
+                  <Chip
+                    icon={typeIcon[evt.type]}
+                    label={chipLabel[evt.type] ?? evt.type}
+                    size="small"
+                    color={typeColor[evt.type] ?? "default"}
+                    sx={{ fontSize: "0.65rem", height: 20 }}
+                  />
+                  <Tooltip title={evt.timestamp} placement="left">
+                    <Typography
+                      variant="caption"
+                      fontFamily="monospace"
+                      color="text.secondary"
+                      sx={{ flexShrink: 0, cursor: "default" }}
+                    >
+                      {formatTime(evt.timestamp)}
+                    </Typography>
+                  </Tooltip>
+                </Box>
+
+                {/* Row 2: full message, wraps freely */}
                 <Typography
                   variant="caption"
-                  fontFamily="monospace"
-                  sx={{ flexShrink: 0 }}
+                  color="text.primary"
+                  sx={{ display: "block", lineHeight: 1.4, wordBreak: "break-word" }}
                 >
-                  {formatTime(evt.timestamp)}
-                </Typography>
-                <Chip
-                  label={evt.type}
-                  size="small"
-                  color={typeColor[evt.type] ?? "default"}
-                  sx={{ fontSize: "0.7rem", height: 20 }}
-                />
-                <Typography variant="caption" noWrap sx={{ minWidth: 0 }}>
                   {evt.message}
                 </Typography>
               </Box>


### PR DESCRIPTION
## Summary

- Messages now wrap freely — no more mid-sentence truncation
- Responsive `maxHeight` (xs/sm/md) replaces the fixed 300px ceiling
- `AcquisitionStarted` = green, `AcquisitionStopped` = grey — operationally opposite states are now visually distinct
- 2-line layout per event: chip + timestamp on row 1, full message on row 2
- Short chip labels (`START`/`STOP`/`DROP`/`BUF`/`ERROR`) recover ~60px of horizontal space
- Left accent border per severity for fast visual scanning
- Smart auto-scroll: only follows new events when already near the bottom; doesn't interrupt manual review
- Newest events appear at top (reversed order)
- Timestamp tooltip reveals full ISO datetime on hover
- Header shows total event count

## Test plan

- [ ] Start acquisition — verify `START` chip is green, message is fully readable
- [ ] Stop acquisition — verify `STOP` chip is grey (distinct from green START)
- [ ] Generate 20+ events — verify scroll container expands past 300px on md screens
- [ ] Scroll up to review history — confirm auto-scroll does NOT hijack position
- [ ] Hover a timestamp — verify full ISO datetime appears in tooltip
- [ ] Narrow the browser to xs — verify layout remains usable at 240px height

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)