### PR TITLE
feat: show all captured images in gallery

### DIFF
--- a/src/peanut-vision-ui/src/api/types.ts
+++ b/src/peanut-vision-ui/src/api/types.ts
@@ -84,3 +84,10 @@ export interface ApiMessage {
 export interface ApiError {
   error: string;
 }
+
+export interface CapturedImage {
+  id: string;
+  url: string;
+  blob: Blob;
+  capturedAt: Date;
+}

--- a/src/peanut-vision-ui/src/components/CapturedImageList.tsx
+++ b/src/peanut-vision-ui/src/components/CapturedImageList.tsx
@@ -1,0 +1,103 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import DeleteSweepIcon from "@mui/icons-material/DeleteSweep";
+import type { CapturedImage } from "../api/types";
+
+interface Props {
+  images: CapturedImage[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onClear: () => void;
+}
+
+function formatTime(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+}
+
+export default function CapturedImageList({ images, selectedId, onSelect, onClear }: Props) {
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+        <Typography variant="subtitle2" color="text.secondary">
+          Captured Images ({images.length})
+        </Typography>
+        {images.length > 0 && (
+          <Button
+            size="small"
+            color="error"
+            startIcon={<DeleteSweepIcon />}
+            onClick={onClear}
+          >
+            Clear All
+          </Button>
+        )}
+      </Box>
+
+      {images.length === 0 ? (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: 80,
+            border: "1px dashed",
+            borderColor: "divider",
+            borderRadius: 1,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary">
+            No images captured
+          </Typography>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            overflowX: "auto",
+            pb: 1,
+            "&::-webkit-scrollbar": { height: 4 },
+            "&::-webkit-scrollbar-thumb": { borderRadius: 2, bgcolor: "divider" },
+          }}
+        >
+          {images.map((img) => (
+            <Box
+              key={img.id}
+              onClick={() => onSelect(img.id)}
+              sx={{
+                flexShrink: 0,
+                cursor: "pointer",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 80,
+                  height: 60,
+                  border: "2px solid",
+                  borderColor: img.id === selectedId ? "primary.main" : "divider",
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  transition: "border-color 0.15s",
+                }}
+              >
+                <img
+                  src={img.url}
+                  alt={`Capture at ${formatTime(img.capturedAt)}`}
+                  style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                />
+              </Box>
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.65rem" }}>
+                {formatTime(img.capturedAt)}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ImageViewer.tsx
+++ b/src/peanut-vision-ui/src/components/ImageViewer.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
@@ -6,23 +5,12 @@ import Typography from "@mui/material/Typography";
 import DownloadIcon from "@mui/icons-material/Download";
 
 interface Props {
-  blob: Blob | null;
+  url: string | null;
+  filename?: string;
   errorMessage?: string | null;
 }
 
-export default function ImageViewer({ blob, errorMessage }: Props) {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!blob) {
-      setUrl(null);
-      return;
-    }
-    const objectUrl = URL.createObjectURL(blob);
-    setUrl(objectUrl);
-    return () => URL.revokeObjectURL(objectUrl);
-  }, [blob]);
-
+export default function ImageViewer({ url, filename, errorMessage }: Props) {
   if (!url) {
     return (
       <Box
@@ -75,7 +63,7 @@ export default function ImageViewer({ blob, errorMessage }: Props) {
         size="small"
         startIcon={<DownloadIcon />}
         href={url}
-        download={`capture-${Date.now()}.png`}
+        download={filename ?? `capture-${Date.now()}.png`}
       >
         Download
       </Button>

--- a/src/peanut-vision-ui/src/constants.ts
+++ b/src/peanut-vision-ui/src/constants.ts
@@ -1,4 +1,5 @@
 export const API_BASE_URL = "http://localhost:5000/api";
+export const MAX_CAPTURED_IMAGES = 30;
 export const POLL_INTERVAL_MS = 3000;
 export const REFRESH_THROTTLE_MS = 3000;
 export const DEFAULT_EXPOSURE_MIN = 100;

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -8,8 +8,9 @@ import AcquisitionControls from "../components/AcquisitionControls";
 import AcquisitionStats from "../components/AcquisitionStats";
 import EventLog from "../components/EventLog";
 import ImageViewer from "../components/ImageViewer";
+import CapturedImageList from "../components/CapturedImageList";
 import ContinuousSettings from "../components/ContinuousSettings";
-import type { AcquisitionMode, AcquisitionStatus, CamFileInfo } from "../api/types";
+import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage } from "../api/types";
 import {
   getCameras,
   startAcquisition,
@@ -24,7 +25,12 @@ import { usePolling } from "../hooks/usePolling";
 import {
   POLL_INTERVAL_ACTIVE_MS,
   POLL_INTERVAL_IDLE_MS,
+  MAX_CAPTURED_IMAGES,
 } from "../constants";
+
+function formatFilenameTimestamp(d: Date): string {
+  return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}_${String(d.getHours()).padStart(2, "0")}${String(d.getMinutes()).padStart(2, "0")}${String(d.getSeconds()).padStart(2, "0")}_${String(d.getMilliseconds()).padStart(3, "0")}`;
+}
 
 export default function AcquisitionTab() {
   const [cameras, setCameras] = useState<CamFileInfo[]>([]);
@@ -33,7 +39,8 @@ export default function AcquisitionTab() {
   const [frameCount, setFrameCount] = useState<number | null>(null);
   const [intervalMs, setIntervalMs] = useState<number | null>(null);
   const [status, setStatus] = useState<AcquisitionStatus | null>(null);
-  const [capturedBlob, setCapturedBlob] = useState<Blob | null>(null);
+  const [images, setImages] = useState<CapturedImage[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [snackbar, setSnackbar] = useState<{
     message: string;
     severity: "success" | "info" | "warning" | "error";
@@ -62,19 +69,51 @@ export default function AcquisitionTab() {
       .catch(() => {});
   }, []);
 
+  const addImage = useCallback((blob: Blob) => {
+    const url = URL.createObjectURL(blob);
+    const newImage: CapturedImage = { id: crypto.randomUUID(), url, blob, capturedAt: new Date() };
+    setImages((prev) => {
+      const next = [newImage, ...prev];
+      if (next.length > MAX_CAPTURED_IMAGES) {
+        next.slice(MAX_CAPTURED_IMAGES).forEach((img) => URL.revokeObjectURL(img.url));
+        return next.slice(0, MAX_CAPTURED_IMAGES);
+      }
+      return next;
+    });
+    setSelectedId(newImage.id);
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    setImages((prev) => {
+      prev.forEach((img) => URL.revokeObjectURL(img.url));
+      return [];
+    });
+    setSelectedId(null);
+  }, []);
+
+  // Revoke all URLs on unmount
+  useEffect(() => {
+    return () => {
+      setImages((prev) => {
+        prev.forEach((img) => URL.revokeObjectURL(img.url));
+        return prev;
+      });
+    };
+  }, []);
+
   // Live preview: poll latest frame while acquisition is active and has frames
   useEffect(() => {
     if (!status?.isActive || !status?.hasFrame) return;
     const t = setInterval(async () => {
       try {
         const blob = await getLatestFrame();
-        if (blob) setCapturedBlob(blob);
+        if (blob) addImage(blob);
       } catch {
         /* ignore */
       }
     }, 1000);
     return () => clearInterval(t);
-  }, [status?.isActive, status?.hasFrame]);
+  }, [status?.isActive, status?.hasFrame, addImage]);
 
   const handleStart = () =>
     execute(async () => {
@@ -92,7 +131,7 @@ export default function AcquisitionTab() {
 
   const handleTrigger = () =>
     execute(async () => {
-      setCapturedBlob(await triggerAndCapture());
+      addImage(await triggerAndCapture());
       fetchStatus();
       setSnackbar({
         message: "프레임이 촬영되었습니다",
@@ -102,13 +141,15 @@ export default function AcquisitionTab() {
 
   const handleCapture = () =>
     execute(async () => {
-      setCapturedBlob(await snapshot(selectedProfile));
+      addImage(await snapshot(selectedProfile));
       fetchStatus();
       setSnackbar({
         message: "스냅샷이 촬영되었습니다",
         severity: "success",
       });
     });
+
+  const selectedImage = images.find((img) => img.id === selectedId) ?? null;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -150,7 +191,19 @@ export default function AcquisitionTab() {
           </Box>
         </Grid>
         <Grid size={{ xs: 12, md: 8 }}>
-          <ImageViewer blob={capturedBlob} errorMessage={status?.lastError} />
+          <Box sx={{ display: "flex", flexDirection: "column" }}>
+            <ImageViewer
+              url={selectedImage?.url ?? null}
+              filename={selectedImage ? `capture-${formatFilenameTimestamp(selectedImage.capturedAt)}.png` : undefined}
+              errorMessage={status?.lastError}
+            />
+            <CapturedImageList
+              images={images}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              onClear={handleClearAll}
+            />
+          </Box>
         </Grid>
       </Grid>
 


### PR DESCRIPTION
Closes #23

## Summary
- Replace single `capturedBlob` state with `CapturedImage[]` so every captured frame accumulates instead of being overwritten
- Add `CapturedImageList` component: horizontally scrollable thumbnail strip with HH:mm:ss captions and selection highlight
- Update `ImageViewer` to accept a pre-created `url` string instead of a `Blob` — URL lifecycle now owned by `AcquisitionTab`
- Cap gallery at 30 images; evicted/cleared/unmounted images have their Object URLs properly revoked

## Test plan
- [ ] Start continuous acquisition — thumbnails accumulate newest-first in the strip
- [ ] Click an older thumbnail — main viewer shows that image
- [ ] New frames keep appending without disrupting the current selection
- [ ] "Clear All" empties the strip and resets the viewer to placeholder
- [ ] Single snapshot/trigger also adds to the gallery
- [ ] Run `npx playwright test` — existing E2E suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)