### PR TITLE
Fix calibration command value, explicit AcquisitionMode, and SignalInfo doc

### DIFF
--- a/src/PeanutVision.MultiCamDriver/Camera/CamFileInfo.cs
+++ b/src/PeanutVision.MultiCamDriver/Camera/CamFileInfo.cs
@@ -23,13 +23,15 @@ public sealed record CamFileInfo(
     public GrabChannelOptions ToChannelOptions(int driverIndex = 0, string connector = "M",
         int surfaceCount = 4, bool useCallback = true)
     {
+        var trigMode = ParseTrigMode(TrigMode);
         return new GrabChannelOptions
         {
             DriverIndex = driverIndex,
             Connector = connector,
             CamFilePath = FilePath,
             SurfaceCount = surfaceCount,
-            TriggerMode = ParseTrigMode(TrigMode),
+            TriggerMode = trigMode,
+            AcquisitionMode = DeriveAcquisitionMode(trigMode),
             UseCallback = useCallback
         };
     }
@@ -54,6 +56,23 @@ public sealed record CamFileInfo(
             "HARD" => McTrigMode.MC_TrigMode_HARD,
             "COMBINED" => McTrigMode.MC_TrigMode_COMBINED,
             _ => McTrigMode.MC_TrigMode_IMMEDIATE
+        };
+    }
+
+    /// <summary>
+    /// Derives the appropriate acquisition mode for area-scan cameras based on trigger mode.
+    /// SOFT/HARD/COMBINED triggers use SNAPSHOT; IMMEDIATE (freerun) uses VIDEO.
+    /// PAGE/WEB/LONGPAGE are never valid for TC-A160K area-scan cameras.
+    /// </summary>
+    private static McAcquisitionMode DeriveAcquisitionMode(McTrigMode trigMode)
+    {
+        return trigMode switch
+        {
+            McTrigMode.MC_TrigMode_SOFT => McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT,
+            McTrigMode.MC_TrigMode_HARD => McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT,
+            McTrigMode.MC_TrigMode_COMBINED => McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT,
+            McTrigMode.MC_TrigMode_IMMEDIATE => McAcquisitionMode.MC_AcquisitionMode_VIDEO,
+            _ => McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT
         };
     }
 }

--- a/src/PeanutVision.MultiCamDriver/GrabChannel.cs
+++ b/src/PeanutVision.MultiCamDriver/GrabChannel.cs
@@ -27,6 +27,9 @@ public class GrabChannelOptions
 
     /// <summary>Trigger mode for acquisition</summary>
     public McTrigMode TriggerMode { get; set; } = McTrigMode.MC_TrigMode_IMMEDIATE;
+
+    /// <summary>Acquisition mode (SNAPSHOT, VIDEO, HFR). Must match the camera type — never use PAGE/WEB/LONGPAGE with TC-A160K area-scan cameras.</summary>
+    public McAcquisitionMode AcquisitionMode { get; set; } = McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT;
 }
 
 /// <summary>
@@ -162,6 +165,17 @@ public sealed class GrabChannel : IDisposable
             };
             status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_TrigMode, trigModeStr);
             ThrowOnError(status, $"SetParam(TrigMode={trigModeStr})");
+
+            // Set acquisition mode explicitly — never rely on cam file defaults
+            string acqModeStr = options.AcquisitionMode switch
+            {
+                McAcquisitionMode.MC_AcquisitionMode_SNAPSHOT => MultiCamApi.MC_AcquisitionMode_SNAPSHOT_STR,
+                McAcquisitionMode.MC_AcquisitionMode_VIDEO => MultiCamApi.MC_AcquisitionMode_VIDEO_STR,
+                McAcquisitionMode.MC_AcquisitionMode_HFR => MultiCamApi.MC_AcquisitionMode_HFR_STR,
+                _ => throw new ArgumentException($"Unsupported acquisition mode for area-scan camera: {options.AcquisitionMode}")
+            };
+            status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_AcquisitionMode, acqModeStr);
+            ThrowOnError(status, $"SetParam(AcquisitionMode={acqModeStr})");
 
             // Enable surface processing signal
             SetSignalEnable(McSignal.MC_SIG_SURFACE_PROCESSING, true);
@@ -639,7 +653,7 @@ public sealed class GrabChannel : IDisposable
         {
             ThrowIfDisposed();
 
-            int status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_BlackCalibration, "ON");
+            int status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_BlackCalibration, MultiCamApi.MC_Calibration_Execute);
             ThrowOnError(status, "BlackCalibration");
         }
     }
@@ -654,7 +668,7 @@ public sealed class GrabChannel : IDisposable
         {
             ThrowIfDisposed();
 
-            int status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_WhiteCalibration, "ON");
+            int status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_WhiteCalibration, MultiCamApi.MC_Calibration_Execute);
             ThrowOnError(status, "WhiteCalibration");
         }
     }
@@ -668,7 +682,7 @@ public sealed class GrabChannel : IDisposable
         {
             ThrowIfDisposed();
 
-            string value = enable ? "ON" : "OFF";
+            string value = enable ? MultiCamApi.MC_FlatFieldCorrection_ON : MultiCamApi.MC_FlatFieldCorrection_OFF;
             int status = _hal.SetParamStr(_channelHandle, MultiCamApi.PN_FlatFieldCorrection, value);
             ThrowOnError(status, $"SetFlatFieldCorrection({value})");
         }

--- a/src/PeanutVision.MultiCamDriver/MultiCamApi.cs
+++ b/src/PeanutVision.MultiCamDriver/MultiCamApi.cs
@@ -137,7 +137,7 @@ public struct McSignalInfo
 	public uint Instance;
 	/// <summary>Signal identifier (McSignal value)</summary>
 	public int Signal;
-	/// <summary>Additional signal-specific information (e.g., surface index for SURFACE_PROCESSING)</summary>
+	/// <summary>Additional signal-specific information (e.g., surface handle for SURFACE_PROCESSING — not a zero-based index)</summary>
 	public uint SignalInfo;
 	/// <summary>Signal context information</summary>
 	public uint SignalContext;
@@ -221,6 +221,16 @@ public static partial class MultiCamApi
 
 	// ForceTrig string values
 	public const string MC_ForceTrig_STR = "TRIG";
+
+	// Acquisition mode string values
+	public const string MC_AcquisitionMode_SNAPSHOT_STR = "SNAPSHOT";
+	public const string MC_AcquisitionMode_VIDEO_STR = "VIDEO";
+	public const string MC_AcquisitionMode_HFR_STR = "HFR";
+
+	// Calibration command values
+	public const string MC_Calibration_Execute = "Execute";
+	public const string MC_FlatFieldCorrection_ON = "ON";
+	public const string MC_FlatFieldCorrection_OFF = "OFF";
 
 	#endregion
 


### PR DESCRIPTION
## Summary

- **Issue #1 (CRITICAL):** `PerformBlackCalibration` and `PerformWhiteCalibration` sent `"ON"` to the driver instead of `"Execute"` — calibration was silently skipped, leaving cameras uncalibrated
- **Issue #3 (HIGH):** `AcquisitionMode` was never set explicitly on channel creation; the driver inherited whatever the `.cam` file last configured, making behavior non-deterministic
- **Issue #10 (LOW):** `McSignalInfo.SignalInfo` XML doc said "surface index" (implying a zero-based array index) when it is actually an opaque surface handle

## What Changed

### `MultiCamApi.cs`
- Fixed `McSignalInfo.SignalInfo` doc comment: "surface handle ... not a zero-based index"
- Added acquisition mode string constants: `MC_AcquisitionMode_SNAPSHOT_STR`, `MC_AcquisitionMode_VIDEO_STR`, `MC_AcquisitionMode_HFR_STR`
- Added calibration command constants: `MC_Calibration_Execute = "Execute"`, `MC_FlatFieldCorrection_ON = "ON"`, `MC_FlatFieldCorrection_OFF = "OFF"`

### `GrabChannel.cs`
- Added `AcquisitionMode` property to `GrabChannelOptions` (default: `SNAPSHOT`)
- `CreateChannel()` now explicitly calls `SetParam(AcquisitionMode)` after `TrigMode` is set — never relies on cam file defaults
- `PerformBlackCalibration()`: `"ON"` → `MultiCamApi.MC_Calibration_Execute` (`"Execute"`)
- `PerformWhiteCalibration()`: `"ON"` → `MultiCamApi.MC_Calibration_Execute` (`"Execute"`)
- `SetFlatFieldCorrection()`: raw `"ON"`/`"OFF"` → named constants

### `CamFileInfo.cs`
- `ToChannelOptions()` now sets `AcquisitionMode` via `DeriveAcquisitionMode()` based on trigger mode
- New helper `DeriveAcquisitionMode()`: SOFT/HARD/COMBINED → SNAPSHOT; IMMEDIATE → VIDEO

## Why

### Issue #1 Root Cause
The MultiCam SDK requires the string value `"Execute"` to trigger calibration commands. `"ON"` is a valid value for boolean/toggle parameters (like `FlatFieldCorrection`), but calibration parameters (`BlackCalibration`, `WhiteCalibration`) expect a command token. Sending `"ON"` results in `MC_INVALID_VALUE` which was being thrown as an exception — meaning no calibration could ever succeed.

### Issue #3 Root Cause
The driver's behavior when `AcquisitionMode` is not set depends on the last value written — either by the cam file parser or by a previous session. For area-scan cameras like the TC-A160K, PAGE/WEB/LONGPAGE modes are invalid and could cause driver errors. Explicit configuration at channel creation time makes behavior deterministic regardless of cam file content.

### Issue #10 Root Cause
`SignalInfo` in `McSignalInfo` is documented in the Euresys SDK as containing the surface handle (an opaque `uint` identifier), not a zero-based array index. Code that treats it as an index and uses it with buffer arrays would produce incorrect memory access.

## Channel Initialization Flow — Before vs After

```mermaid
flowchart TD
    subgraph BEFORE["Before (Issues #1 & #3)"]
        B1[McCreate MC_CHANNEL] --> B2[SetParam DriverIndex]
        B2 --> B3[SetParam Connector]
        B3 --> B4[SetParam CamFile]
        B4 --> B5[SetParam SurfaceCount]
        B5 --> B6[SetParam TrigMode]
        B6 --> B7[Enable Signals]
        B7 --> B8[Register Callback]

        C1[PerformBlackCalibration] --> C2["SetParam BlackCalibration = 'ON'"]
        C2 --> C3["❌ MC_INVALID_VALUE — calibration never executes"]

        B4 -.->|AcquisitionMode not set| D1["Driver inherits unknown state from cam file"]
    end

    subgraph AFTER["After (Fixed)"]
        A1[McCreate MC_CHANNEL] --> A2[SetParam DriverIndex]
        A2 --> A3[SetParam Connector]
        A3 --> A4[SetParam CamFile]
        A4 --> A5[SetParam SurfaceCount]
        A5 --> A6[SetParam TrigMode]
        A6 --> A7["SetParam AcquisitionMode ✅ (explicit)"]
        A7 --> A8[Enable Signals]
        A8 --> A9[Register Callback]

        E1[PerformBlackCalibration] --> E2["SetParam BlackCalibration = 'Execute'"]
        E2 --> E3["✅ MC_OK — FFC black calibration runs"]
    end
```

## CamFileInfo AcquisitionMode Derivation

```mermaid
flowchart LR
    TM[TrigMode from .cam file] --> SW{Switch}
    SW -->|SOFT| SN[SNAPSHOT]
    SW -->|HARD| SN
    SW -->|COMBINED| SN
    SW -->|IMMEDIATE| VD[VIDEO]
    SW -->|other| SN
    SN --> OPT[GrabChannelOptions.AcquisitionMode]
    VD --> OPT
```

## Test Plan

- [ ] Build passes: `dotnet build` — 0 errors, 0 warnings
- [ ] Unit tests pass: `dotnet test src/PeanutVision.MultiCamDriver.Tests`
- [ ] Verify `PerformBlackCalibration()` sends `"Execute"` (not `"ON"`) via mock HAL test
- [ ] Verify `CreateChannel()` calls `SetParam("AcquisitionMode", "SNAPSHOT")` for SOFT trigger mode
- [ ] Verify `CamFileInfo.ToChannelOptions()` with `TrigMode="IMMEDIATE"` sets `AcquisitionMode=VIDEO`
- [ ] Verify `CamFileInfo.ToChannelOptions()` with `TrigMode="SOFT"` sets `AcquisitionMode=SNAPSHOT`
- [ ] Verify `McSignalInfo.SignalInfo` doc is accurate in IDE hover tooltip

Closes #1, Closes #3, Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)