### PR TITLE
Fix: Start button tooltip shows wrong message when profile is selected

### DIFF
--- a/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
@@ -121,8 +121,12 @@ export default function AcquisitionControls({
           ) : (
             <Tooltip
               title={
-                busy || !allowed("start") || !selectedProfile
+                !selectedProfile
                   ? "프로파일을 선택하세요"
+                  : busy
+                  ? "처리 중..."
+                  : !allowed("start")
+                  ? "시작할 수 없습니다"
                   : "연속 촬영 시작"
               }
             >


### PR DESCRIPTION
## Summary
- Start button tooltip always showed "프로파일을 선택하세요" even when a profile was already selected
- Fixed by checking each disable condition separately and returning the correct message per reason

## Root Cause
The ternary condition `busy || !allowed("start") || !selectedProfile` collapsed all three disable reasons into one tooltip message.

## Fix
Cascade the conditions independently:
1. `!selectedProfile` → "프로파일을 선택하세요"
2. `busy` → "처리 중..."
3. `!allowed("start")` → "시작할 수 없습니다"
4. Otherwise → "연속 촬영 시작"

## Test plan
- [ ] No profile selected: tooltip shows "프로파일을 선택하세요"
- [ ] Profile selected, driver busy: tooltip shows "처리 중..."
- [ ] Profile selected, start not allowed (driver not ready): tooltip shows "시작할 수 없습니다"
- [ ] Profile selected and ready: tooltip shows "연속 촬영 시작" and button is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)