### PR TITLE
feat: image save settings with JSON file persistence

### DIFF
--- a/src/PeanutVision.Api/Controllers/AcquisitionController.cs
+++ b/src/PeanutVision.Api/Controllers/AcquisitionController.cs
@@ -10,19 +10,20 @@ namespace PeanutVision.Api.Controllers;
 public class AcquisitionController : ControllerBase
 {
     private readonly IAcquisitionService _acquisition;
-    private readonly string? _imageOutputDirectory;
+    private readonly IImageSaveSettingsService _saveSettings;
+    private readonly FilenameGenerator _filenameGenerator;
+    private readonly string _contentRootPath;
 
-    public AcquisitionController(IAcquisitionService acquisition, IConfiguration configuration, IWebHostEnvironment environment)
+    public AcquisitionController(
+        IAcquisitionService acquisition,
+        IImageSaveSettingsService saveSettings,
+        FilenameGenerator filenameGenerator,
+        IWebHostEnvironment environment)
     {
         _acquisition = acquisition;
-
-        var outputDir = configuration["ImageOutputDirectory"];
-        if (!string.IsNullOrEmpty(outputDir))
-        {
-            _imageOutputDirectory = Path.IsPathRooted(outputDir)
-                ? outputDir
-                : Path.Combine(environment.ContentRootPath, outputDir);
-        }
+        _saveSettings = saveSettings;
+        _filenameGenerator = filenameGenerator;
+        _contentRootPath = environment.ContentRootPath;
     }
 
     [HttpPost("start")]
@@ -106,11 +107,11 @@ public class AcquisitionController : ControllerBase
         {
             var image = await _acquisition.TriggerAndWaitAsync(5000);
 
-            if (_imageOutputDirectory is not null)
+            var settings = _saveSettings.GetSettings();
+            if (settings.AutoSave)
             {
-                Directory.CreateDirectory(_imageOutputDirectory);
-                var fileName = $"trigger_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
-                var filePath = Path.Combine(_imageOutputDirectory, fileName);
+                var filePath = _filenameGenerator.Generate(
+                    settings, _contentRootPath, _acquisition.ActiveProfileId?.Value);
                 new ImageWriter().Save(image, filePath);
                 Response.Headers["X-Image-Path"] = filePath;
             }
@@ -161,8 +162,19 @@ public class AcquisitionController : ControllerBase
 
             if (!string.IsNullOrWhiteSpace(request.OutputPath))
             {
-                var writer = new ImageWriter();
-                writer.Save(image, request.OutputPath);
+                new ImageWriter().Save(image, request.OutputPath);
+                Response.Headers["X-Image-Path"] = request.OutputPath;
+            }
+            else
+            {
+                var settings = _saveSettings.GetSettings();
+                if (settings.AutoSave)
+                {
+                    var filePath = _filenameGenerator.Generate(
+                        settings, _contentRootPath, request.ProfileId);
+                    new ImageWriter().Save(image, filePath);
+                    Response.Headers["X-Image-Path"] = filePath;
+                }
             }
 
             var encoder = new PngEncoder();

--- a/src/PeanutVision.Api/Controllers/SettingsController.cs
+++ b/src/PeanutVision.Api/Controllers/SettingsController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using PeanutVision.Api.Services;
+
+namespace PeanutVision.Api.Controllers;
+
+[ApiController]
+[Route("api/settings")]
+public class SettingsController : ControllerBase
+{
+    private readonly IImageSaveSettingsService _service;
+
+    public SettingsController(IImageSaveSettingsService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("image-save")]
+    public ActionResult<ImageSaveSettings> GetImageSaveSettings() => Ok(_service.GetSettings());
+
+    [HttpPut("image-save")]
+    public async Task<ActionResult<ImageSaveSettings>> UpdateImageSaveSettings(
+        [FromBody] ImageSaveSettings settings)
+    {
+        var errors = Validate(settings);
+        if (errors.Count > 0)
+            return BadRequest(new { errors });
+
+        await _service.SaveSettingsAsync(settings);
+        return Ok(settings);
+    }
+
+    private static List<string> Validate(ImageSaveSettings settings)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(settings.FilenamePrefix))
+            errors.Add("FilenamePrefix is required");
+        else if (settings.FilenamePrefix.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            errors.Add("FilenamePrefix contains invalid filename characters");
+
+        if (string.IsNullOrWhiteSpace(settings.TimestampFormat))
+            errors.Add("TimestampFormat is required");
+        else
+        {
+            try { _ = DateTime.Now.ToString(settings.TimestampFormat); }
+            catch { errors.Add("TimestampFormat is not a valid date/time format string"); }
+        }
+
+        return errors;
+    }
+}

--- a/src/PeanutVision.Api/Program.cs
+++ b/src/PeanutVision.Api/Program.cs
@@ -36,6 +36,10 @@ else
     builder.Services.AddGrabService(autoInitialize: true);
 }
 
+var saveSettingsPath = Path.Combine(builder.Environment.ContentRootPath, "image-save-settings.json");
+builder.Services.AddSingleton<IImageSaveSettingsService>(new ImageSaveSettingsService(saveSettingsPath));
+builder.Services.AddSingleton<FilenameGenerator>();
+
 builder.Services.AddSingleton<AcquisitionManager>();
 builder.Services.AddSingleton<IAcquisitionService>(sp => sp.GetRequiredService<AcquisitionManager>());
 builder.Services.AddSingleton<IChannelCalibration>(sp => sp.GetRequiredService<AcquisitionManager>());

--- a/src/PeanutVision.Api/Services/FilenameGenerator.cs
+++ b/src/PeanutVision.Api/Services/FilenameGenerator.cs
@@ -1,0 +1,55 @@
+namespace PeanutVision.Api.Services;
+
+public sealed class FilenameGenerator
+{
+    private readonly string _sessionTimestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+    private int _sequenceCounter;
+
+    public string Generate(ImageSaveSettings settings, string contentRootPath, string? profileId = null)
+    {
+        var now = DateTime.Now;
+        var baseDir = ResolveDirectory(settings.OutputDirectory, contentRootPath);
+
+        var subdir = settings.SubfolderStrategy switch
+        {
+            SubfolderStrategy.ByDate => now.ToString("yyyy-MM-dd"),
+            SubfolderStrategy.BySession => $"session_{_sessionTimestamp}",
+            SubfolderStrategy.ByProfile when !string.IsNullOrEmpty(profileId) => SanitizeSegment(profileId),
+            _ => null,
+        };
+
+        var dir = subdir is not null ? Path.Combine(baseDir, subdir) : baseDir;
+        Directory.CreateDirectory(dir);
+
+        var prefix = string.IsNullOrWhiteSpace(settings.FilenamePrefix) ? "capture" : settings.FilenamePrefix;
+        var ext = settings.Format switch
+        {
+            SaveImageFormat.Bmp => ".bmp",
+            SaveImageFormat.Raw => ".raw",
+            _ => ".png",
+        };
+
+        string name;
+        if (settings.IncludeSequenceNumber)
+        {
+            var seq = Interlocked.Increment(ref _sequenceCounter);
+            name = $"{prefix}_{now.ToString(settings.TimestampFormat)}_{seq:D5}{ext}";
+        }
+        else
+        {
+            name = $"{prefix}_{now.ToString(settings.TimestampFormat)}{ext}";
+        }
+
+        return Path.Combine(dir, name);
+    }
+
+    private static string ResolveDirectory(string outputDir, string contentRootPath)
+    {
+        if (string.IsNullOrWhiteSpace(outputDir))
+            return Path.Combine(contentRootPath, "CapturedImages");
+        return Path.IsPathRooted(outputDir) ? outputDir : Path.Combine(contentRootPath, outputDir);
+    }
+
+    private static string SanitizeSegment(string segment) =>
+        string.Concat(segment.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
+}

--- a/src/PeanutVision.Api/Services/ImageSaveSettings.cs
+++ b/src/PeanutVision.Api/Services/ImageSaveSettings.cs
@@ -1,0 +1,16 @@
+namespace PeanutVision.Api.Services;
+
+public enum SaveImageFormat { Png, Bmp, Raw }
+
+public enum SubfolderStrategy { None, ByDate, BySession, ByProfile }
+
+public sealed record ImageSaveSettings
+{
+    public string OutputDirectory { get; init; } = "CapturedImages";
+    public SaveImageFormat Format { get; init; } = SaveImageFormat.Png;
+    public string FilenamePrefix { get; init; } = "capture";
+    public string TimestampFormat { get; init; } = "yyyyMMdd_HHmmss_fff";
+    public bool IncludeSequenceNumber { get; init; } = false;
+    public SubfolderStrategy SubfolderStrategy { get; init; } = SubfolderStrategy.None;
+    public bool AutoSave { get; init; } = true;
+}

--- a/src/PeanutVision.Api/Services/ImageSaveSettingsService.cs
+++ b/src/PeanutVision.Api/Services/ImageSaveSettingsService.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+
+namespace PeanutVision.Api.Services;
+
+public interface IImageSaveSettingsService
+{
+    ImageSaveSettings GetSettings();
+    Task SaveSettingsAsync(ImageSaveSettings settings);
+}
+
+public sealed class ImageSaveSettingsService : IImageSaveSettingsService
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+    private volatile ImageSaveSettings _settings;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    public ImageSaveSettingsService(string filePath)
+    {
+        _filePath = filePath;
+        _settings = Load();
+    }
+
+    public ImageSaveSettings GetSettings() => _settings;
+
+    public async Task SaveSettingsAsync(ImageSaveSettings settings)
+    {
+        await _writeLock.WaitAsync();
+        try
+        {
+            var json = JsonSerializer.Serialize(settings, _jsonOptions);
+            await File.WriteAllTextAsync(_filePath, json);
+            _settings = settings;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private ImageSaveSettings Load()
+    {
+        if (!File.Exists(_filePath)) return new ImageSaveSettings();
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize<ImageSaveSettings>(json) ?? new ImageSaveSettings();
+        }
+        catch
+        {
+            return new ImageSaveSettings();
+        }
+    }
+}

--- a/src/PeanutVision.Api/appsettings.json
+++ b/src/PeanutVision.Api/appsettings.json
@@ -4,7 +4,6 @@
     "FrameDelayMs": 0
   },
   "CamFileDirectory": "CamFiles",
-  "ImageOutputDirectory": "CapturedImages",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/peanut-vision-ui/src/api/client.ts
+++ b/src/peanut-vision-ui/src/api/client.ts
@@ -6,7 +6,13 @@ import type {
   AcquisitionStatus,
   ExposureInfo,
   ApiMessage,
+  ImageSaveSettings,
 } from "./types";
+
+export interface CaptureResult {
+  blob: Blob;
+  savedPath?: string;
+}
 
 async function handleErrorResponse(res: Response): Promise<never> {
   const body = await res.json().catch(() => ({}));
@@ -63,25 +69,27 @@ export function getAcquisitionStatus(): Promise<AcquisitionStatus> {
   return request("/acquisition/status");
 }
 
-export async function triggerAndCapture(): Promise<Blob> {
+export async function triggerAndCapture(): Promise<CaptureResult> {
   const res = await fetch(`${API_BASE_URL}/acquisition/trigger`, {
     method: "POST",
   });
   if (!res.ok) await handleErrorResponse(res);
-  return res.blob();
+  const savedPath = res.headers.get("X-Image-Path") ?? undefined;
+  return { blob: await res.blob(), savedPath };
 }
 
 export async function snapshot(
   profileId: string,
   triggerMode?: string,
-): Promise<Blob> {
+): Promise<CaptureResult> {
   const res = await fetch(`${API_BASE_URL}/acquisition/snapshot`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ profileId, triggerMode }),
   });
   if (!res.ok) await handleErrorResponse(res);
-  return res.blob();
+  const savedPath = res.headers.get("X-Image-Path") ?? undefined;
+  return { blob: await res.blob(), savedPath };
 }
 
 export async function getLatestFrame(): Promise<Blob | null> {
@@ -89,6 +97,21 @@ export async function getLatestFrame(): Promise<Blob | null> {
   if (res.status === 204) return null;
   if (!res.ok) await handleErrorResponse(res);
   return res.blob();
+}
+
+// ── Settings ──
+
+export function getImageSaveSettings(): Promise<ImageSaveSettings> {
+  return request("/settings/image-save");
+}
+
+export function updateImageSaveSettings(
+  settings: ImageSaveSettings,
+): Promise<ImageSaveSettings> {
+  return request("/settings/image-save", {
+    method: "PUT",
+    body: JSON.stringify(settings),
+  });
 }
 
 // ── Calibration ──

--- a/src/peanut-vision-ui/src/api/types.ts
+++ b/src/peanut-vision-ui/src/api/types.ts
@@ -59,6 +59,8 @@ export interface ChannelEvent {
 
 export type AcquisitionAction = "start" | "stop" | "trigger" | "snapshot";
 
+export type ChannelState = "none" | "idle" | "active";
+
 export type AcquisitionMode = "single" | "continuous";
 
 export interface AcquisitionStatus {
@@ -90,4 +92,18 @@ export interface CapturedImage {
   url: string;
   blob: Blob;
   capturedAt: Date;
+  savedPath?: string;
+}
+
+export type SaveImageFormat = "png" | "bmp" | "raw";
+export type SubfolderStrategy = "none" | "byDate" | "bySession" | "byProfile";
+
+export interface ImageSaveSettings {
+  outputDirectory: string;
+  format: SaveImageFormat;
+  filenamePrefix: string;
+  timestampFormat: string;
+  includeSequenceNumber: boolean;
+  subfolderStrategy: SubfolderStrategy;
+  autoSave: boolean;
 }

--- a/src/peanut-vision-ui/src/components/ChannelStateIndicator.tsx
+++ b/src/peanut-vision-ui/src/components/ChannelStateIndicator.tsx
@@ -1,0 +1,41 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import type { ChannelState } from "../api/types";
+
+interface Props {
+  state: ChannelState;
+}
+
+const stateConfig: Record<ChannelState, { color: string; label: string; pulse: boolean }> = {
+  none:   { color: "#9e9e9e", label: "No Channel",           pulse: false },
+  idle:   { color: "#ffc107", label: "Channel Idle (IDLE)",  pulse: false },
+  active: { color: "#4caf50", label: "Channel Active (ACTIVE)", pulse: true },
+};
+
+export default function ChannelStateIndicator({ state }: Props) {
+  const { color, label, pulse } = stateConfig[state];
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Box
+        sx={{
+          width: 12,
+          height: 12,
+          borderRadius: "50%",
+          backgroundColor: color,
+          flexShrink: 0,
+          ...(pulse && {
+            animation: "pulse 1.5s ease-in-out infinite",
+            "@keyframes pulse": {
+              "0%, 100%": { opacity: 1, transform: "scale(1)" },
+              "50%":       { opacity: 0.6, transform: "scale(1.3)" },
+            },
+          }),
+        }}
+      />
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ImageSaveSettingsPanel.tsx
+++ b/src/peanut-vision-ui/src/components/ImageSaveSettingsPanel.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import MenuItem from "@mui/material/MenuItem";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import Alert from "@mui/material/Alert";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FolderIcon from "@mui/icons-material/Folder";
+import type { ImageSaveSettings, SaveImageFormat, SubfolderStrategy } from "../api/types";
+import { getImageSaveSettings, updateImageSaveSettings } from "../api/client";
+
+const FORMAT_OPTIONS: { value: SaveImageFormat; label: string }[] = [
+  { value: "png", label: "PNG" },
+  { value: "bmp", label: "BMP" },
+  { value: "raw", label: "RAW" },
+];
+
+const SUBFOLDER_OPTIONS: { value: SubfolderStrategy; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "byDate", label: "By Date (YYYY-MM-DD)" },
+  { value: "bySession", label: "By Session" },
+  { value: "byProfile", label: "By Profile" },
+];
+
+const DEFAULT_SETTINGS: ImageSaveSettings = {
+  outputDirectory: "CapturedImages",
+  format: "png",
+  filenamePrefix: "capture",
+  timestampFormat: "yyyyMMdd_HHmmss_fff",
+  includeSequenceNumber: false,
+  subfolderStrategy: "none",
+  autoSave: true,
+};
+
+export default function ImageSaveSettingsPanel() {
+  const [settings, setSettings] = useState<ImageSaveSettings>(DEFAULT_SETTINGS);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    getImageSaveSettings()
+      .then(setSettings)
+      .catch(() => {});
+  }, []);
+
+  const handleSave = async () => {
+    setBusy(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await updateImageSaveSettings(settings);
+      setSettings(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save settings");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const update = <K extends keyof ImageSaveSettings>(key: K, value: ImageSaveSettings[K]) =>
+    setSettings((prev) => ({ ...prev, [key]: value }));
+
+  const exampleFilename = [
+    settings.filenamePrefix || "capture",
+    "20260320_143000_123",
+    settings.includeSequenceNumber ? "00001" : null,
+  ]
+    .filter(Boolean)
+    .join("_") + `.${settings.format}`;
+
+  return (
+    <Accordion disableGutters variant="outlined">
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <FolderIcon fontSize="small" color="action" />
+          <Typography variant="subtitle2">Image Save Settings</Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Output Directory"
+              size="small"
+              value={settings.outputDirectory}
+              onChange={(e) => update("outputDirectory", e.target.value)}
+              helperText="Relative to app root, or absolute path"
+              sx={{ flexGrow: 1, minWidth: 220 }}
+            />
+            <TextField
+              select
+              label="Format"
+              size="small"
+              value={settings.format}
+              onChange={(e) => update("format", e.target.value as SaveImageFormat)}
+              sx={{ width: 110 }}
+            >
+              {FORMAT_OPTIONS.map((o) => (
+                <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>
+              ))}
+            </TextField>
+          </Box>
+
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Filename Prefix"
+              size="small"
+              value={settings.filenamePrefix}
+              onChange={(e) => update("filenamePrefix", e.target.value)}
+              sx={{ width: 160 }}
+            />
+            <TextField
+              label="Timestamp Format"
+              size="small"
+              value={settings.timestampFormat}
+              onChange={(e) => update("timestampFormat", e.target.value)}
+              helperText=".NET DateTime format"
+              sx={{ width: 200 }}
+            />
+            <TextField
+              select
+              label="Subfolder"
+              size="small"
+              value={settings.subfolderStrategy}
+              onChange={(e) => update("subfolderStrategy", e.target.value as SubfolderStrategy)}
+              sx={{ width: 200 }}
+            >
+              {SUBFOLDER_OPTIONS.map((o) => (
+                <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>
+              ))}
+            </TextField>
+          </Box>
+
+          <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={settings.autoSave}
+                  onChange={(e) => update("autoSave", e.target.checked)}
+                />
+              }
+              label="Auto-save on capture"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={settings.includeSequenceNumber}
+                  onChange={(e) => update("includeSequenceNumber", e.target.checked)}
+                />
+              }
+              label="Include sequence number"
+            />
+          </Box>
+
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+            <Typography variant="caption" color="text.secondary">
+              Example: <strong>{exampleFilename}</strong>
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Button
+              size="small"
+              variant="contained"
+              onClick={handleSave}
+              disabled={busy}
+            >
+              Save Settings
+            </Button>
+          </Box>
+
+          {error && <Alert severity="error" sx={{ py: 0 }}>{error}</Alert>}
+          {saved && <Alert severity="success" sx={{ py: 0 }}>Settings saved</Alert>}
+        </Box>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ImageViewer.tsx
+++ b/src/peanut-vision-ui/src/components/ImageViewer.tsx
@@ -1,16 +1,19 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import DownloadIcon from "@mui/icons-material/Download";
+import SaveIcon from "@mui/icons-material/Save";
 
 interface Props {
   url: string | null;
   filename?: string;
   errorMessage?: string | null;
+  savedPath?: string;
 }
 
-export default function ImageViewer({ url, filename, errorMessage }: Props) {
+export default function ImageViewer({ url, filename, errorMessage, savedPath }: Props) {
   if (!url) {
     return (
       <Box
@@ -59,14 +62,31 @@ export default function ImageViewer({ url, filename, errorMessage }: Props) {
           </Box>
         )}
       </Box>
-      <Button
-        size="small"
-        startIcon={<DownloadIcon />}
-        href={url}
-        download={filename ?? `capture-${Date.now()}.png`}
-      >
-        Download
-      </Button>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <Button
+          size="small"
+          startIcon={<DownloadIcon />}
+          href={url}
+          download={filename ?? `capture-${Date.now()}.png`}
+        >
+          Download
+        </Button>
+        {savedPath && (
+          <Tooltip title={savedPath}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0 }}>
+              <SaveIcon sx={{ fontSize: 14, color: "success.main", flexShrink: 0 }} />
+              <Typography
+                variant="caption"
+                color="success.main"
+                noWrap
+                sx={{ maxWidth: 300 }}
+              >
+                {savedPath}
+              </Typography>
+            </Box>
+          </Tooltip>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -10,6 +10,7 @@ import EventLog from "../components/EventLog";
 import ImageViewer from "../components/ImageViewer";
 import CapturedImageList from "../components/CapturedImageList";
 import ContinuousSettings from "../components/ContinuousSettings";
+import ImageSaveSettingsPanel from "../components/ImageSaveSettingsPanel";
 import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage } from "../api/types";
 import {
   getCameras,
@@ -69,9 +70,9 @@ export default function AcquisitionTab() {
       .catch(() => {});
   }, []);
 
-  const addImage = useCallback((blob: Blob) => {
+  const addImage = useCallback((blob: Blob, savedPath?: string) => {
     const url = URL.createObjectURL(blob);
-    const newImage: CapturedImage = { id: crypto.randomUUID(), url, blob, capturedAt: new Date() };
+    const newImage: CapturedImage = { id: crypto.randomUUID(), url, blob, capturedAt: new Date(), savedPath };
     setImages((prev) => {
       const next = [newImage, ...prev];
       if (next.length > MAX_CAPTURED_IMAGES) {
@@ -131,7 +132,8 @@ export default function AcquisitionTab() {
 
   const handleTrigger = () =>
     execute(async () => {
-      addImage(await triggerAndCapture());
+      const { blob, savedPath } = await triggerAndCapture();
+      addImage(blob, savedPath);
       fetchStatus();
       setSnackbar({
         message: "프레임이 촬영되었습니다",
@@ -141,7 +143,8 @@ export default function AcquisitionTab() {
 
   const handleCapture = () =>
     execute(async () => {
-      addImage(await snapshot(selectedProfile));
+      const { blob, savedPath } = await snapshot(selectedProfile);
+      addImage(blob, savedPath);
       fetchStatus();
       setSnackbar({
         message: "스냅샷이 촬영되었습니다",
@@ -183,6 +186,8 @@ export default function AcquisitionTab() {
         />
       )}
 
+      <ImageSaveSettingsPanel />
+
       <Grid container spacing={3}>
         <Grid size={{ xs: 12, md: 4 }}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -196,6 +201,7 @@ export default function AcquisitionTab() {
               url={selectedImage?.url ?? null}
               filename={selectedImage ? `capture-${formatFilenameTimestamp(selectedImage.capturedAt)}.png` : undefined}
               errorMessage={status?.lastError}
+              savedPath={selectedImage?.savedPath}
             />
             <CapturedImageList
               images={images}


### PR DESCRIPTION
## Summary

- Add runtime-configurable image save settings persisted to `image-save-settings.json` (no database dependency, survives restarts)
- Expose `GET /PUT /api/settings/image-save` to read and write settings
- Replace hardcoded `ImageOutputDirectory` + `trigger_{timestamp}.png` naming with a flexible `FilenameGenerator`
- Show the saved file path in the UI after every capture

## Persistence approach

Settings are stored in `{ContentRootPath}/image-save-settings.json`, loaded at startup, and written atomically via `SemaphoreSlim`. Falls back to defaults if the file is missing or corrupt. No ORM or database required.

## New files

| File | Purpose |
|---|---|
| `Services/ImageSaveSettings.cs` | Settings record + `SaveImageFormat` / `SubfolderStrategy` enums |
| `Services/ImageSaveSettingsService.cs` | `IImageSaveSettingsService` — load/save JSON file |
| `Services/FilenameGenerator.cs` | Builds full file paths from settings (prefix, timestamp, sequence, subfolder) |
| `Controllers/SettingsController.cs` | `GET/PUT /api/settings/image-save` with input validation |
| `components/ImageSaveSettingsPanel.tsx` | Collapsible settings accordion in the Acquisition tab |

## Settings

| Field | Type | Default | Description |
|---|---|---|---|
| `outputDirectory` | string | `CapturedImages` | Save directory (relative or absolute) |
| `format` | `png`/`bmp`/`raw` | `png` | File format |
| `filenamePrefix` | string | `capture` | Filename leading text |
| `timestampFormat` | string | `yyyyMMdd_HHmmss_fff` | .NET DateTime format |
| `subfolderStrategy` | `none`/`byDate`/`bySession`/`byProfile` | `none` | Automatic subfoldering |
| `includeSequenceNumber` | bool | false | Append 5-digit counter `_00001` |
| `autoSave` | bool | true | Save on every capture |

## Note on test failure

`Status_when_idle_allowed_actions_contains_start_and_snapshot` fails on `main` before this PR (pre-existing issue tracked in `fix/start-button-tooltip-message`).

## Test plan

- [ ] Default settings → `CapturedImages/capture_<timestamp>.png` created on snapshot/trigger
- [ ] Each `subfolderStrategy` creates the correct directory structure
- [ ] Each `format` produces a valid file (PNG/BMP/RAW)
- [ ] `includeSequenceNumber` increments correctly across multiple captures
- [ ] `autoSave = false` → no file written, no `X-Image-Path` header
- [ ] Settings survive app restart (file re-read on next startup)
- [ ] `PUT` with empty `filenamePrefix` → `400` with error list
- [ ] `PUT` with invalid `timestampFormat` → `400` with error message
- [ ] Saved path label appears under the image in the UI after trigger/snapshot
- [ ] `image-save-settings.json` is created on first `PUT` if it didn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)