### PR TITLE
Sprint 2: session management + ImageSaveSettings tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -490,5 +490,8 @@ setup/sdk_pdfs/
 # Runtime output
 CapturedImages/
 
+# SQLite databases
+*.db
+
 # Claude
 .mcp.json

--- a/src/PeanutVision.Api.Tests/Infrastructure/PeanutVisionApiFactory.cs
+++ b/src/PeanutVision.Api.Tests/Infrastructure/PeanutVisionApiFactory.cs
@@ -1,8 +1,10 @@
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using PeanutVision.Api.Services;
 using PeanutVision.MultiCamDriver;
 using PeanutVision.MultiCamDriver.Camera;
 using PeanutVision.MultiCamDriver.Hal;
@@ -13,6 +15,7 @@ public class PeanutVisionApiFactory : WebApplicationFactory<Program>
 {
     public MockMultiCamHAL MockHal { get; } = new();
     private IntPtr _surfaceMemory;
+    private readonly string _testDbPath = Path.Combine(Path.GetTempPath(), $"pv-test-{Guid.NewGuid():N}.db");
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -41,6 +44,12 @@ public class PeanutVisionApiFactory : WebApplicationFactory<Program>
                 service.Initialize();
                 return service;
             });
+
+            // Replace DbContext with test-specific SQLite file
+            services.RemoveAll<DbContextOptions<AppDbContext>>();
+            services.RemoveAll<AppDbContext>();
+            services.AddDbContext<AppDbContext>(options =>
+                options.UseSqlite($"Data Source={_testDbPath}"));
         });
     }
 
@@ -57,5 +66,6 @@ public class PeanutVisionApiFactory : WebApplicationFactory<Program>
             Marshal.FreeHGlobal(_surfaceMemory);
             _surfaceMemory = IntPtr.Zero;
         }
+        try { File.Delete(_testDbPath); } catch { /* ignore */ }
     }
 }

--- a/src/PeanutVision.Api.Tests/PeanutVision.Api.Tests.csproj
+++ b/src/PeanutVision.Api.Tests/PeanutVision.Api.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/PeanutVision.Api.Tests/Unit/ImageSaveSettingsServiceTests.cs
+++ b/src/PeanutVision.Api.Tests/Unit/ImageSaveSettingsServiceTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using PeanutVision.Api.Services;
+
+namespace PeanutVision.Api.Tests.Unit;
+
+public class ImageSaveSettingsServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+
+    public ImageSaveSettingsServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"pv-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    public class Given_no_existing_file : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public void Then_returns_default_settings()
+        {
+            var service = new ImageSaveSettingsService(_filePath);
+            var settings = service.GetSettings();
+
+            Assert.Equal("CapturedImages", settings.OutputDirectory);
+            Assert.Equal(SaveImageFormat.Png, settings.Format);
+            Assert.Equal("capture", settings.FilenamePrefix);
+            Assert.Equal("yyyyMMdd_HHmmss_fff", settings.TimestampFormat);
+            Assert.False(settings.IncludeSequenceNumber);
+            Assert.Equal(SubfolderStrategy.None, settings.SubfolderStrategy);
+            Assert.True(settings.AutoSave);
+        }
+    }
+
+    public class Given_existing_valid_file : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public void Then_loads_settings_from_file()
+        {
+            var expected = new ImageSaveSettings
+            {
+                OutputDirectory = "/custom/path",
+                Format = SaveImageFormat.Bmp,
+                FilenamePrefix = "test",
+                TimestampFormat = "HHmmss",
+                IncludeSequenceNumber = true,
+                SubfolderStrategy = SubfolderStrategy.ByDate,
+                AutoSave = false,
+            };
+            File.WriteAllText(_filePath, JsonSerializer.Serialize(expected));
+
+            var service = new ImageSaveSettingsService(_filePath);
+            var settings = service.GetSettings();
+
+            Assert.Equal("/custom/path", settings.OutputDirectory);
+            Assert.Equal(SaveImageFormat.Bmp, settings.Format);
+            Assert.Equal("test", settings.FilenamePrefix);
+            Assert.Equal("HHmmss", settings.TimestampFormat);
+            Assert.True(settings.IncludeSequenceNumber);
+            Assert.Equal(SubfolderStrategy.ByDate, settings.SubfolderStrategy);
+            Assert.False(settings.AutoSave);
+        }
+    }
+
+    public class Given_corrupt_file : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public void Then_falls_back_to_defaults()
+        {
+            File.WriteAllText(_filePath, "{ invalid json !!!");
+
+            var service = new ImageSaveSettingsService(_filePath);
+            var settings = service.GetSettings();
+
+            Assert.Equal("CapturedImages", settings.OutputDirectory);
+            Assert.Equal(SaveImageFormat.Png, settings.Format);
+        }
+    }
+
+    public class Given_empty_file : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public void Then_falls_back_to_defaults()
+        {
+            File.WriteAllText(_filePath, "");
+
+            var service = new ImageSaveSettingsService(_filePath);
+            var settings = service.GetSettings();
+
+            Assert.Equal("CapturedImages", settings.OutputDirectory);
+        }
+    }
+
+    public class When_saving_settings : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public async Task Then_persists_to_file()
+        {
+            var service = new ImageSaveSettingsService(_filePath);
+            var newSettings = new ImageSaveSettings
+            {
+                OutputDirectory = "/saved/path",
+                Format = SaveImageFormat.Raw,
+                FilenamePrefix = "saved",
+                TimestampFormat = "yyyyMMdd",
+                IncludeSequenceNumber = true,
+                SubfolderStrategy = SubfolderStrategy.ByProfile,
+                AutoSave = false,
+            };
+
+            await service.SaveSettingsAsync(newSettings);
+
+            Assert.True(File.Exists(_filePath));
+            var json = File.ReadAllText(_filePath);
+            var loaded = JsonSerializer.Deserialize<ImageSaveSettings>(json);
+            Assert.NotNull(loaded);
+            Assert.Equal("/saved/path", loaded.OutputDirectory);
+            Assert.Equal(SaveImageFormat.Raw, loaded.Format);
+        }
+
+        [Fact]
+        public async Task Then_in_memory_settings_updated()
+        {
+            var service = new ImageSaveSettingsService(_filePath);
+            var newSettings = new ImageSaveSettings { FilenamePrefix = "updated" };
+
+            await service.SaveSettingsAsync(newSettings);
+
+            Assert.Equal("updated", service.GetSettings().FilenamePrefix);
+        }
+
+        [Fact]
+        public async Task Then_file_is_indented_json()
+        {
+            var service = new ImageSaveSettingsService(_filePath);
+            await service.SaveSettingsAsync(new ImageSaveSettings());
+
+            var json = File.ReadAllText(_filePath);
+            Assert.Contains("\n", json);
+            Assert.Contains("  ", json);
+        }
+    }
+
+    public class When_reloading_after_save : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public async Task Then_new_instance_reads_saved_settings()
+        {
+            var service1 = new ImageSaveSettingsService(_filePath);
+            await service1.SaveSettingsAsync(new ImageSaveSettings { FilenamePrefix = "roundtrip" });
+
+            var service2 = new ImageSaveSettingsService(_filePath);
+            Assert.Equal("roundtrip", service2.GetSettings().FilenamePrefix);
+        }
+    }
+
+    public class When_saving_concurrently : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public async Task Then_no_exceptions_thrown()
+        {
+            var service = new ImageSaveSettingsService(_filePath);
+            var tasks = Enumerable.Range(0, 10).Select(i =>
+                service.SaveSettingsAsync(new ImageSaveSettings { FilenamePrefix = $"concurrent-{i}" }));
+
+            await Task.WhenAll(tasks);
+
+            // Verify final state is one of the saved values
+            var settings = service.GetSettings();
+            Assert.StartsWith("concurrent-", settings.FilenamePrefix);
+        }
+    }
+
+    public class Given_partial_json_schema : ImageSaveSettingsServiceTests
+    {
+        [Fact]
+        public void Then_missing_fields_get_defaults()
+        {
+            // Write JSON with only some fields
+            File.WriteAllText(_filePath, """{"FilenamePrefix":"partial"}""");
+
+            var service = new ImageSaveSettingsService(_filePath);
+            var settings = service.GetSettings();
+
+            Assert.Equal("partial", settings.FilenamePrefix);
+            // Missing fields should get their default values
+            Assert.Equal("CapturedImages", settings.OutputDirectory);
+            Assert.Equal(SaveImageFormat.Png, settings.Format);
+            Assert.True(settings.AutoSave);
+        }
+    }
+}

--- a/src/PeanutVision.Api/Controllers/SessionController.cs
+++ b/src/PeanutVision.Api/Controllers/SessionController.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Mvc;
+using PeanutVision.Api.Services;
+
+namespace PeanutVision.Api.Controllers;
+
+[ApiController]
+[Route("api/sessions")]
+public class SessionController : ControllerBase
+{
+    private readonly ISessionRepository _repository;
+
+    public SessionController(ISessionRepository repository) => _repository = repository;
+
+    public record CreateSessionRequest(string Name, string? Notes = null);
+    public record UpdateSessionRequest(string? Name = null, string? Notes = null);
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<Session>>> GetAll([FromQuery] int limit = 50)
+        => Ok(await _repository.GetAllAsync(limit));
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Session>> GetById(Guid id)
+    {
+        var session = await _repository.GetByIdAsync(id);
+        return session is null ? NotFound(new { error = $"Session {id} not found" }) : Ok(session);
+    }
+
+    [HttpGet("active")]
+    public async Task<ActionResult<Session>> GetActive()
+    {
+        var session = await _repository.GetActiveAsync();
+        return session is null ? NoContent() : Ok(session);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Session>> Create([FromBody] CreateSessionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return BadRequest(new { error = "Session name is required" });
+
+        var session = await _repository.CreateAsync(request.Name, request.Notes);
+        return CreatedAtAction(nameof(GetById), new { id = session.Id }, session);
+    }
+
+    [HttpPost("{id:guid}/end")]
+    public async Task<ActionResult<Session>> End(Guid id)
+    {
+        try
+        {
+            var session = await _repository.EndSessionAsync(id);
+            return Ok(session);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { error = $"Session {id} not found" });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<Session>> Update(Guid id, [FromBody] UpdateSessionRequest request)
+    {
+        try
+        {
+            var session = await _repository.UpdateAsync(id, request.Name, request.Notes);
+            return Ok(session);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { error = $"Session {id} not found" });
+        }
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        try
+        {
+            await _repository.DeleteAsync(id);
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { error = $"Session {id} not found" });
+        }
+    }
+}

--- a/src/PeanutVision.Api/PeanutVision.Api.csproj
+++ b/src/PeanutVision.Api/PeanutVision.Api.csproj
@@ -13,6 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
   </ItemGroup>
 

--- a/src/PeanutVision.Api/Program.cs
+++ b/src/PeanutVision.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
 using PeanutVision.Api.Services;
 using PeanutVision.FakeCamDriver;
 using PeanutVision.MultiCamDriver;
@@ -40,6 +41,11 @@ var saveSettingsPath = Path.Combine(builder.Environment.ContentRootPath, "image-
 builder.Services.AddSingleton<IImageSaveSettingsService>(new ImageSaveSettingsService(saveSettingsPath));
 builder.Services.AddSingleton<FilenameGenerator>();
 
+var dbPath = Path.Combine(builder.Environment.ContentRootPath, "peanut-vision.db");
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+builder.Services.AddScoped<ISessionRepository, SessionRepository>();
+
 builder.Services.AddSingleton<AcquisitionManager>();
 builder.Services.AddSingleton<IAcquisitionService>(sp => sp.GetRequiredService<AcquisitionManager>());
 builder.Services.AddSingleton<IChannelCalibration>(sp => sp.GetRequiredService<AcquisitionManager>());
@@ -60,6 +66,13 @@ var app = builder.Build();
 if (useMock)
 {
     app.Logger.LogWarning("FakeCamDriver enabled — using test pattern generator (no hardware)");
+}
+
+// Ensure SQLite database and schema are created
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
 }
 
 app.UseCors();

--- a/src/PeanutVision.Api/Services/AppDbContext.cs
+++ b/src/PeanutVision.Api/Services/AppDbContext.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace PeanutVision.Api.Services;
+
+public sealed class AppDbContext : DbContext
+{
+    public DbSet<Session> Sessions => Set<Session>();
+
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Session>(entity =>
+        {
+            entity.HasKey(s => s.Id);
+            entity.Property(s => s.Name).HasMaxLength(200).IsRequired();
+            entity.Property(s => s.Notes).HasMaxLength(2000);
+            entity.HasIndex(s => s.CreatedAt);
+        });
+    }
+}

--- a/src/PeanutVision.Api/Services/ISessionRepository.cs
+++ b/src/PeanutVision.Api/Services/ISessionRepository.cs
@@ -1,0 +1,12 @@
+namespace PeanutVision.Api.Services;
+
+public interface ISessionRepository
+{
+    Task<Session> CreateAsync(string name, string? notes = null);
+    Task<Session?> GetByIdAsync(Guid id);
+    Task<IReadOnlyList<Session>> GetAllAsync(int limit = 50);
+    Task<Session?> GetActiveAsync();
+    Task<Session> EndSessionAsync(Guid id);
+    Task<Session> UpdateAsync(Guid id, string? name = null, string? notes = null);
+    Task DeleteAsync(Guid id);
+}

--- a/src/PeanutVision.Api/Services/Session.cs
+++ b/src/PeanutVision.Api/Services/Session.cs
@@ -1,0 +1,12 @@
+namespace PeanutVision.Api.Services;
+
+public sealed class Session
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? EndedAt { get; set; }
+    public string? Notes { get; set; }
+
+    public bool IsActive => EndedAt is null;
+}

--- a/src/PeanutVision.Api/Services/SessionRepository.cs
+++ b/src/PeanutVision.Api/Services/SessionRepository.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace PeanutVision.Api.Services;
+
+public sealed class SessionRepository : ISessionRepository
+{
+    private readonly AppDbContext _db;
+
+    public SessionRepository(AppDbContext db) => _db = db;
+
+    public async Task<Session> CreateAsync(string name, string? notes = null)
+    {
+        var session = new Session
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatedAt = DateTime.UtcNow,
+            Notes = notes,
+        };
+
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+        return session;
+    }
+
+    public async Task<Session?> GetByIdAsync(Guid id)
+        => await _db.Sessions.FindAsync(id);
+
+    public async Task<IReadOnlyList<Session>> GetAllAsync(int limit = 50)
+        => await _db.Sessions
+            .OrderByDescending(s => s.CreatedAt)
+            .Take(limit)
+            .ToListAsync();
+
+    public async Task<Session?> GetActiveAsync()
+        => await _db.Sessions
+            .Where(s => s.EndedAt == null)
+            .OrderByDescending(s => s.CreatedAt)
+            .FirstOrDefaultAsync();
+
+    public async Task<Session> EndSessionAsync(Guid id)
+    {
+        var session = await _db.Sessions.FindAsync(id)
+            ?? throw new KeyNotFoundException($"Session {id} not found");
+
+        if (session.EndedAt is not null)
+            throw new InvalidOperationException($"Session {id} is already ended");
+
+        session.EndedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return session;
+    }
+
+    public async Task<Session> UpdateAsync(Guid id, string? name = null, string? notes = null)
+    {
+        var session = await _db.Sessions.FindAsync(id)
+            ?? throw new KeyNotFoundException($"Session {id} not found");
+
+        if (name is not null) session.Name = name;
+        if (notes is not null) session.Notes = notes;
+
+        await _db.SaveChangesAsync();
+        return session;
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        var session = await _db.Sessions.FindAsync(id)
+            ?? throw new KeyNotFoundException($"Session {id} not found");
+
+        _db.Sessions.Remove(session);
+        await _db.SaveChangesAsync();
+    }
+}

--- a/src/peanut-vision-ui/src/api/client.ts
+++ b/src/peanut-vision-ui/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   ExposureInfo,
   ApiMessage,
   ImageSaveSettings,
+  Session,
 } from "./types";
 
 export interface CaptureResult {
@@ -112,6 +113,39 @@ export function updateImageSaveSettings(
     method: "PUT",
     body: JSON.stringify(settings),
   });
+}
+
+// ── Sessions ──
+
+export function getSessions(limit = 50): Promise<Session[]> {
+  return request(`/sessions?limit=${limit}`);
+}
+
+export function getActiveSession(): Promise<Session | null> {
+  return fetch(`${API_BASE_URL}/sessions/active`)
+    .then((res) => {
+      if (res.status === 204) return null;
+      if (!res.ok) return res.json().then((b) => { throw new Error(b.error ?? `HTTP ${res.status}`); });
+      return res.json();
+    });
+}
+
+export function createSession(name: string, notes?: string): Promise<Session> {
+  return request("/sessions", {
+    method: "POST",
+    body: JSON.stringify({ name, notes }),
+  });
+}
+
+export function endSession(id: string): Promise<Session> {
+  return request(`/sessions/${id}/end`, { method: "POST" });
+}
+
+export function deleteSession(id: string): Promise<void> {
+  return fetch(`${API_BASE_URL}/sessions/${id}`, { method: "DELETE" })
+    .then((res) => {
+      if (!res.ok) return res.json().then((b) => { throw new Error(b.error ?? `HTTP ${res.status}`); });
+    });
 }
 
 // ── Calibration ──

--- a/src/peanut-vision-ui/src/api/types.ts
+++ b/src/peanut-vision-ui/src/api/types.ts
@@ -95,6 +95,15 @@ export interface CapturedImage {
   savedPath?: string;
 }
 
+export interface Session {
+  id: string;
+  name: string;
+  createdAt: string;
+  endedAt: string | null;
+  notes: string | null;
+  isActive: boolean;
+}
+
 export type SaveImageFormat = "png" | "bmp" | "raw";
 export type SubfolderStrategy = "none" | "byDate" | "bySession" | "byProfile";
 

--- a/src/peanut-vision-ui/src/components/SessionSelector.tsx
+++ b/src/peanut-vision-ui/src/components/SessionSelector.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import AddIcon from "@mui/icons-material/Add";
+import StopIcon from "@mui/icons-material/Stop";
+import HistoryIcon from "@mui/icons-material/History";
+import DeleteIcon from "@mui/icons-material/Delete";
+import type { Session } from "../api/types";
+import {
+  getSessions,
+  getActiveSession,
+  createSession,
+  endSession,
+  deleteSession,
+} from "../api/client";
+
+export default function SessionSelector() {
+  const [activeSession, setActiveSession] = useState<Session | null>(null);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [newOpen, setNewOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newNotes, setNewNotes] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [active, all] = await Promise.all([getActiveSession(), getSessions()]);
+      setActiveSession(active);
+      setSessions(all);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    setBusy(true);
+    try {
+      await createSession(newName.trim(), newNotes.trim() || undefined);
+      setNewName("");
+      setNewNotes("");
+      setNewOpen(false);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleEnd = async () => {
+    if (!activeSession) return;
+    setBusy(true);
+    try {
+      await endSession(activeSession.id);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setBusy(true);
+    try {
+      await deleteSession(id);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleString();
+  };
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+      <Typography variant="subtitle2" color="text.secondary">
+        Session:
+      </Typography>
+
+      {activeSession ? (
+        <>
+          <Chip
+            label={activeSession.name}
+            color="primary"
+            size="small"
+            variant="outlined"
+          />
+          <Button
+            size="small"
+            color="warning"
+            startIcon={<StopIcon />}
+            onClick={handleEnd}
+            disabled={busy}
+          >
+            End Session
+          </Button>
+        </>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          No active session
+        </Typography>
+      )}
+
+      <Button
+        size="small"
+        startIcon={<AddIcon />}
+        onClick={() => setNewOpen(true)}
+        disabled={busy}
+      >
+        New Session
+      </Button>
+
+      <IconButton size="small" onClick={() => setHistoryOpen(true)}>
+        <HistoryIcon fontSize="small" />
+      </IconButton>
+
+      {/* New Session Dialog */}
+      <Dialog open={newOpen} onClose={() => setNewOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>New Session</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Session Name"
+            fullWidth
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+          />
+          <TextField
+            margin="dense"
+            label="Notes (optional)"
+            fullWidth
+            multiline
+            rows={2}
+            value={newNotes}
+            onChange={(e) => setNewNotes(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNewOpen(false)}>Cancel</Button>
+          <Button onClick={handleCreate} disabled={busy || !newName.trim()} variant="contained">
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* History Dialog */}
+      <Dialog open={historyOpen} onClose={() => setHistoryOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Session History</DialogTitle>
+        <DialogContent>
+          {sessions.length === 0 ? (
+            <Typography color="text.secondary" sx={{ py: 2 }}>
+              No sessions yet
+            </Typography>
+          ) : (
+            <List dense>
+              {sessions.map((s) => (
+                <ListItemButton key={s.id} sx={{ borderRadius: 1 }}>
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        {s.name}
+                        {s.isActive && <Chip label="Active" size="small" color="success" />}
+                      </Box>
+                    }
+                    secondary={
+                      <>
+                        {formatDate(s.createdAt)}
+                        {s.endedAt && ` — ${formatDate(s.endedAt)}`}
+                        {s.notes && ` | ${s.notes}`}
+                      </>
+                    }
+                  />
+                  {!s.isActive && (
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      onClick={(e) => { e.stopPropagation(); handleDelete(s.id); }}
+                      disabled={busy}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setHistoryOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -16,6 +16,7 @@ import ImageViewer from "../components/ImageViewer";
 import CapturedImageList from "../components/CapturedImageList";
 import ContinuousSettings from "../components/ContinuousSettings";
 import ImageSaveSettingsPanel from "../components/ImageSaveSettingsPanel";
+import SessionSelector from "../components/SessionSelector";
 import CalibrationActions from "../components/CalibrationActions";
 import ExposureControl from "../components/ExposureControl";
 import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage, ExposureInfo } from "../api/types";
@@ -211,6 +212,8 @@ export default function AcquisitionTab() {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <ErrorAlert error={error} onClose={clearError} />
+
+      <SessionSelector />
 
       <AcquisitionControls
         cameras={cameras}


### PR DESCRIPTION
## Summary
- Added Job/Session management with SQLite persistence (EF Core)
- `Session` model, `ISessionRepository`, `SessionRepository`, `SessionController` with full CRUD
- Session selector UI in Acquisition tab (New Session / End Session / history list)
- 10 unit tests for `ImageSaveSettingsService` (file I/O, fallback to defaults, schema handling, concurrency)

## New Files
- `Services/Session.cs`, `Services/AppDbContext.cs`, `Services/ISessionRepository.cs`, `Services/SessionRepository.cs`
- `Controllers/SessionController.cs`
- `components/SessionSelector.tsx`
- `Unit/ImageSaveSettingsServiceTests.cs`

## Test plan
- [x] `dotnet test` -- 163/164 passed (1 pre-existing flaky: `Trigger_response_contains_valid_png_bytes`)
- [x] `npm run build` -- clean build
- [ ] Manual: create session, verify it appears as active, end it, check history
- [ ] Manual: verify `GET /api/sessions` returns session list

🤖 Generated with [Claude Code](https://claude.com/claude-code)