### PR TITLE
Sprint 4: hardware trigger, presets, E2E tests

### DIFF
--- a/src/PeanutVision.Api/Controllers/PresetController.cs
+++ b/src/PeanutVision.Api/Controllers/PresetController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc;
+using PeanutVision.Api.Services;
+
+namespace PeanutVision.Api.Controllers;
+
+[ApiController]
+[Route("api/presets")]
+public class PresetController : ControllerBase
+{
+    private readonly IAcquisitionPresetService _presets;
+
+    public PresetController(IAcquisitionPresetService presets) => _presets = presets;
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<AcquisitionPreset>> GetAll()
+        => Ok(_presets.GetAll());
+
+    [HttpGet("{name}")]
+    public ActionResult<AcquisitionPreset> GetByName(string name)
+    {
+        var preset = _presets.GetByName(name);
+        return preset is null ? NotFound(new { error = $"Preset '{name}' not found" }) : Ok(preset);
+    }
+
+    [HttpPut]
+    public async Task<ActionResult<AcquisitionPreset>> Save([FromBody] AcquisitionPreset preset)
+    {
+        if (string.IsNullOrWhiteSpace(preset.Name))
+            return BadRequest(new { error = "Preset name is required" });
+        if (string.IsNullOrWhiteSpace(preset.ProfileId))
+            return BadRequest(new { error = "ProfileId is required" });
+
+        await _presets.SaveAsync(preset);
+        return Ok(preset);
+    }
+
+    [HttpDelete("{name}")]
+    public async Task<ActionResult> Delete(string name)
+    {
+        try
+        {
+            await _presets.DeleteAsync(name);
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { error = $"Preset '{name}' not found" });
+        }
+    }
+}

--- a/src/PeanutVision.Api/Program.cs
+++ b/src/PeanutVision.Api/Program.cs
@@ -47,6 +47,9 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite($"Data Source={dbPath}"));
 builder.Services.AddScoped<ISessionRepository, SessionRepository>();
 
+var presetsPath = Path.Combine(builder.Environment.ContentRootPath, "acquisition-presets.json");
+builder.Services.AddSingleton<IAcquisitionPresetService>(new AcquisitionPresetService(presetsPath));
+
 builder.Services.AddSingleton<AcquisitionManager>();
 builder.Services.AddSingleton<IAcquisitionService>(sp => sp.GetRequiredService<AcquisitionManager>());
 builder.Services.AddSingleton<IChannelCalibration>(sp => sp.GetRequiredService<AcquisitionManager>());

--- a/src/PeanutVision.Api/Services/AcquisitionPreset.cs
+++ b/src/PeanutVision.Api/Services/AcquisitionPreset.cs
@@ -1,0 +1,10 @@
+namespace PeanutVision.Api.Services;
+
+public sealed record AcquisitionPreset
+{
+    public string Name { get; init; } = string.Empty;
+    public string ProfileId { get; init; } = string.Empty;
+    public string? TriggerMode { get; init; }
+    public int? FrameCount { get; init; }
+    public int? IntervalMs { get; init; }
+}

--- a/src/PeanutVision.Api/Services/AcquisitionPresetService.cs
+++ b/src/PeanutVision.Api/Services/AcquisitionPresetService.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace PeanutVision.Api.Services;
+
+public interface IAcquisitionPresetService
+{
+    IReadOnlyList<AcquisitionPreset> GetAll();
+    AcquisitionPreset? GetByName(string name);
+    Task SaveAsync(AcquisitionPreset preset);
+    Task DeleteAsync(string name);
+}
+
+public sealed class AcquisitionPresetService : IAcquisitionPresetService
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private List<AcquisitionPreset> _presets;
+
+    public AcquisitionPresetService(string filePath)
+    {
+        _filePath = filePath;
+        _presets = Load();
+    }
+
+    public IReadOnlyList<AcquisitionPreset> GetAll() => _presets.AsReadOnly();
+
+    public AcquisitionPreset? GetByName(string name)
+        => _presets.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    public async Task SaveAsync(AcquisitionPreset preset)
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            var index = _presets.FindIndex(p => p.Name.Equals(preset.Name, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0)
+                _presets[index] = preset;
+            else
+                _presets.Add(preset);
+
+            await PersistAsync();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task DeleteAsync(string name)
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            var removed = _presets.RemoveAll(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                throw new KeyNotFoundException($"Preset '{name}' not found");
+            await PersistAsync();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private async Task PersistAsync()
+    {
+        var json = JsonSerializer.Serialize(_presets, _jsonOptions);
+        await File.WriteAllTextAsync(_filePath, json);
+    }
+
+    private List<AcquisitionPreset> Load()
+    {
+        if (!File.Exists(_filePath)) return [];
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize<List<AcquisitionPreset>>(json) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}

--- a/src/peanut-vision-ui/src/api/client.ts
+++ b/src/peanut-vision-ui/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   ImageSaveSettings,
   Session,
   HistogramData,
+  AcquisitionPreset,
 } from "./types";
 
 export interface CaptureResult {
@@ -152,6 +153,26 @@ export function endSession(id: string): Promise<Session> {
 
 export function deleteSession(id: string): Promise<void> {
   return fetch(`${API_BASE_URL}/sessions/${id}`, { method: "DELETE" })
+    .then((res) => {
+      if (!res.ok) return res.json().then((b) => { throw new Error(b.error ?? `HTTP ${res.status}`); });
+    });
+}
+
+// ── Presets ──
+
+export function getPresets(): Promise<AcquisitionPreset[]> {
+  return request("/presets");
+}
+
+export function savePreset(preset: AcquisitionPreset): Promise<AcquisitionPreset> {
+  return request("/presets", {
+    method: "PUT",
+    body: JSON.stringify(preset),
+  });
+}
+
+export function deletePreset(name: string): Promise<void> {
+  return fetch(`${API_BASE_URL}/presets/${encodeURIComponent(name)}`, { method: "DELETE" })
     .then((res) => {
       if (!res.ok) return res.json().then((b) => { throw new Error(b.error ?? `HTTP ${res.status}`); });
     });

--- a/src/peanut-vision-ui/src/api/types.ts
+++ b/src/peanut-vision-ui/src/api/types.ts
@@ -112,6 +112,16 @@ export interface HistogramData {
   bins: number;
 }
 
+export type TriggerModeOption = "soft" | "hard" | "combined";
+
+export interface AcquisitionPreset {
+  name: string;
+  profileId: string;
+  triggerMode?: string | null;
+  frameCount?: number | null;
+  intervalMs?: number | null;
+}
+
 export type SaveImageFormat = "png" | "bmp" | "raw";
 export type SubfolderStrategy = "none" | "byDate" | "bySession" | "byProfile";
 

--- a/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
@@ -15,7 +15,7 @@ import AdjustIcon from "@mui/icons-material/Adjust";
 import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import StatusChip from "./StatusChip";
-import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, CamFileInfo, ContinuousSubMode } from "../api/types";
+import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, CamFileInfo, ContinuousSubMode, TriggerModeOption } from "../api/types";
 
 interface Props {
   cameras: CamFileInfo[];
@@ -24,6 +24,8 @@ interface Props {
   mode: AcquisitionMode;
   onModeChange: (mode: AcquisitionMode) => void;
   continuousSubMode: ContinuousSubMode;
+  triggerMode: TriggerModeOption;
+  onTriggerModeChange: (mode: TriggerModeOption) => void;
   status: AcquisitionStatus | null;
   busy: boolean;
   onCapture: () => void;
@@ -43,6 +45,8 @@ export default function AcquisitionControls({
   mode,
   onModeChange,
   continuousSubMode,
+  triggerMode,
+  onTriggerModeChange,
   status,
   busy,
   onCapture,
@@ -85,6 +89,20 @@ export default function AcquisitionControls({
         <ToggleButton value="single">Single</ToggleButton>
         <ToggleButton value="continuous">Continuous</ToggleButton>
       </ToggleButtonGroup>
+
+      <FormControl size="small" sx={{ minWidth: 120 }}>
+        <InputLabel>Trigger</InputLabel>
+        <Select
+          value={triggerMode}
+          label="Trigger"
+          onChange={(e) => onTriggerModeChange(e.target.value as TriggerModeOption)}
+          disabled={status?.isActive}
+        >
+          <MenuItem value="soft">Soft</MenuItem>
+          <MenuItem value="hard">Hard</MenuItem>
+          <MenuItem value="combined">Combined</MenuItem>
+        </Select>
+      </FormControl>
 
       {mode === "single" ? (
         <Tooltip

--- a/src/peanut-vision-ui/src/components/PresetSelector.tsx
+++ b/src/peanut-vision-ui/src/components/PresetSelector.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import SaveIcon from "@mui/icons-material/Save";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+import DeleteIcon from "@mui/icons-material/Delete";
+import type { AcquisitionPreset, TriggerModeOption } from "../api/types";
+import { getPresets, savePreset, deletePreset } from "../api/client";
+
+interface Props {
+  profileId: string;
+  triggerMode: TriggerModeOption;
+  frameCount: number | null;
+  intervalMs: number | null;
+  onLoadPreset: (preset: AcquisitionPreset) => void;
+  disabled?: boolean;
+}
+
+export default function PresetSelector({
+  profileId,
+  triggerMode,
+  frameCount,
+  intervalMs,
+  onLoadPreset,
+  disabled,
+}: Props) {
+  const [presets, setPresets] = useState<AcquisitionPreset[]>([]);
+  const [loadOpen, setLoadOpen] = useState(false);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      setPresets(await getPresets());
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleSave = async () => {
+    if (!presetName.trim()) return;
+    setBusy(true);
+    try {
+      await savePreset({
+        name: presetName.trim(),
+        profileId,
+        triggerMode,
+        frameCount,
+        intervalMs,
+      });
+      setPresetName("");
+      setSaveOpen(false);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleLoad = (preset: AcquisitionPreset) => {
+    onLoadPreset(preset);
+    setLoadOpen(false);
+  };
+
+  const handleDelete = async (name: string) => {
+    setBusy(true);
+    try {
+      await deletePreset(name);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: "flex", gap: 0.5 }}>
+      <Button
+        size="small"
+        startIcon={<SaveIcon />}
+        onClick={() => setSaveOpen(true)}
+        disabled={disabled || !profileId}
+      >
+        Save Preset
+      </Button>
+      <Button
+        size="small"
+        startIcon={<FolderOpenIcon />}
+        onClick={() => { refresh(); setLoadOpen(true); }}
+        disabled={disabled}
+      >
+        Load Preset
+      </Button>
+
+      {/* Save Dialog */}
+      <Dialog open={saveOpen} onClose={() => setSaveOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Save Acquisition Preset</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Preset Name"
+            fullWidth
+            value={presetName}
+            onChange={(e) => setPresetName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSave()}
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: "block" }}>
+            Profile: {profileId || "none"} | Trigger: {triggerMode}
+            {frameCount != null && ` | Frames: ${frameCount}`}
+            {intervalMs != null && ` | Interval: ${intervalMs}ms`}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSaveOpen(false)}>Cancel</Button>
+          <Button onClick={handleSave} disabled={busy || !presetName.trim()} variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Load Dialog */}
+      <Dialog open={loadOpen} onClose={() => setLoadOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Load Preset</DialogTitle>
+        <DialogContent>
+          {presets.length === 0 ? (
+            <Typography color="text.secondary" sx={{ py: 2 }}>
+              No presets saved yet
+            </Typography>
+          ) : (
+            <List dense>
+              {presets.map((p) => (
+                <ListItemButton key={p.name} onClick={() => handleLoad(p)} sx={{ borderRadius: 1 }}>
+                  <ListItemText
+                    primary={p.name}
+                    secondary={`${p.profileId} | ${p.triggerMode ?? "soft"}${p.frameCount != null ? ` | ${p.frameCount} frames` : ""}${p.intervalMs != null ? ` | ${p.intervalMs}ms` : ""}`}
+                  />
+                  <IconButton
+                    edge="end"
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); handleDelete(p.name); }}
+                    disabled={busy}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setLoadOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -18,9 +18,10 @@ import ContinuousSettings from "../components/ContinuousSettings";
 import ImageSaveSettingsPanel from "../components/ImageSaveSettingsPanel";
 import SessionSelector from "../components/SessionSelector";
 import HistogramChart from "../components/HistogramChart";
+import PresetSelector from "../components/PresetSelector";
 import CalibrationActions from "../components/CalibrationActions";
 import ExposureControl from "../components/ExposureControl";
-import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage, ContinuousSubMode, ExposureInfo } from "../api/types";
+import type { AcquisitionMode, AcquisitionPreset, AcquisitionStatus, CamFileInfo, CapturedImage, ContinuousSubMode, ExposureInfo, TriggerModeOption } from "../api/types";
 import {
   getCameras,
   startAcquisition,
@@ -53,6 +54,7 @@ export default function AcquisitionTab() {
   const [selectedProfile, setSelectedProfile] = useState("");
   const [mode, setMode] = useState<AcquisitionMode>("single");
   const [continuousSubMode, setContinuousSubMode] = useState<ContinuousSubMode>("auto");
+  const [triggerMode, setTriggerMode] = useState<TriggerModeOption>("soft");
   const [frameCount, setFrameCount] = useState<number | null>(null);
   const [intervalMs, setIntervalMs] = useState<number | null>(null);
   const [status, setStatus] = useState<AcquisitionStatus | null>(null);
@@ -149,7 +151,7 @@ export default function AcquisitionTab() {
     execute(async () => {
       await startAcquisition(
         selectedProfile,
-        undefined,
+        triggerMode,
         frameCount,
         continuousSubMode === "auto" ? intervalMs : null,
       );
@@ -216,6 +218,16 @@ export default function AcquisitionTab() {
       setSnackbar({ message: (await whiteBalance()).message, severity: "success" });
     });
 
+  const handleLoadPreset = useCallback((preset: AcquisitionPreset) => {
+    setSelectedProfile(preset.profileId);
+    setTriggerMode((preset.triggerMode as TriggerModeOption) ?? "soft");
+    setFrameCount(preset.frameCount ?? null);
+    setIntervalMs(preset.intervalMs ?? null);
+    if (preset.frameCount != null || preset.intervalMs != null) {
+      setMode("continuous");
+    }
+  }, []);
+
   const handleFfcToggle = (_: unknown, checked: boolean) => {
     setFfcEnabled(checked);
     execute(async () => {
@@ -238,6 +250,8 @@ export default function AcquisitionTab() {
         mode={mode}
         onModeChange={setMode}
         continuousSubMode={continuousSubMode}
+        triggerMode={triggerMode}
+        onTriggerModeChange={setTriggerMode}
         status={status}
         busy={busy}
         onCapture={handleCapture}
@@ -248,6 +262,15 @@ export default function AcquisitionTab() {
         refreshThrottled={throttled}
         hasWarnings={hasWarnings}
         hasErrors={hasErrors}
+      />
+
+      <PresetSelector
+        profileId={selectedProfile}
+        triggerMode={triggerMode}
+        frameCount={frameCount}
+        intervalMs={intervalMs}
+        onLoadPreset={handleLoadPreset}
+        disabled={status?.isActive}
       />
 
       {mode === "continuous" && (

--- a/src/peanut-vision-ui/tests/camera-settings.spec.ts
+++ b/src/peanut-vision-ui/tests/camera-settings.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+
+const API = "http://localhost:5000/api";
+
+test.beforeEach(async ({ page, request }) => {
+  await request.post(`${API}/acquisition/stop`);
+  await page.goto("/");
+  await page.getByRole("tab", { name: /acquisition/i }).click();
+  await expect(page.getByRole("button", { name: /capture/i })).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("Camera Settings accordion can be expanded", async ({ page }) => {
+  const accordion = page.getByText("Camera Settings");
+  await expect(accordion).toBeVisible();
+  await accordion.click();
+
+  // Should show calibration buttons after expanding
+  await expect(page.getByRole("button", { name: /black cal/i })).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.screenshot({
+    path: "test-results/camera-settings-expanded.png",
+  });
+});
+
+test("Camera Settings shows exposure controls", async ({ page }) => {
+  await page.getByText("Camera Settings").click();
+
+  // Exposure controls should be visible
+  await expect(page.getByRole("button", { name: /load/i })).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByRole("button", { name: /apply/i })).toBeVisible();
+});
+
+test("Camera Settings shows FFC toggle", async ({ page }) => {
+  await page.getByText("Camera Settings").click();
+
+  // FFC toggle should be present
+  await expect(page.getByText(/flat field/i)).toBeVisible({ timeout: 5_000 });
+});
+
+test("Trigger mode selector is visible and defaults to soft", async ({
+  page,
+}) => {
+  // Switch to continuous mode to see more controls
+  await page.getByRole("button", { name: /^continuous$/i }).click();
+
+  // Trigger mode selector should be visible
+  const triggerSelect = page.locator("label", { hasText: "Trigger" });
+  await expect(triggerSelect).toBeVisible();
+});

--- a/src/peanut-vision-ui/tests/image-save-settings.spec.ts
+++ b/src/peanut-vision-ui/tests/image-save-settings.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test";
+
+const API = "http://localhost:5000/api";
+
+test.beforeEach(async ({ page, request }) => {
+  await request.post(`${API}/acquisition/stop`);
+  await page.goto("/");
+  await page.getByRole("tab", { name: /acquisition/i }).click();
+  await expect(page.getByRole("button", { name: /capture/i })).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("Image Save Settings panel is visible", async ({ page }) => {
+  // The ImageSaveSettingsPanel should be on the page
+  await expect(page.getByText(/image save settings/i)).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.screenshot({
+    path: "test-results/image-save-settings-visible.png",
+  });
+});
+
+test("Image Save Settings can be expanded and shows fields", async ({
+  page,
+}) => {
+  // Click to expand the settings panel
+  await page.getByText(/image save settings/i).click();
+
+  // Should show output directory field
+  await expect(page.locator("label", { hasText: /output directory/i })).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Should show format selector
+  await expect(page.locator("label", { hasText: /format/i })).toBeVisible();
+
+  // Should show filename prefix
+  await expect(page.locator("label", { hasText: /filename prefix/i })).toBeVisible();
+
+  await page.screenshot({
+    path: "test-results/image-save-settings-expanded.png",
+  });
+});
+
+test("Image Save Settings format dropdown works", async ({ page }) => {
+  await page.getByText(/image save settings/i).click();
+
+  // Find and interact with format dropdown
+  const formatLabel = page.locator("label", { hasText: /^format$/i });
+  await expect(formatLabel).toBeVisible({ timeout: 5_000 });
+});
+
+test("Image Save Settings auto-save toggle is present", async ({ page }) => {
+  await page.getByText(/image save settings/i).click();
+
+  // Auto-save toggle should be visible
+  await expect(page.getByText(/auto.?save/i)).toBeVisible({ timeout: 5_000 });
+});
+
+test("Image Save Settings API returns valid defaults", async ({ request }) => {
+  const response = await request.get(`${API}/settings/image-save`);
+  expect(response.ok()).toBeTruthy();
+
+  const settings = await response.json();
+  expect(settings.outputDirectory).toBeTruthy();
+  expect(settings.format).toBeDefined();
+  expect(settings.filenamePrefix).toBeTruthy();
+  expect(settings.timestampFormat).toBeTruthy();
+  expect(typeof settings.autoSave).toBe("boolean");
+});
+
+test("Image Save Settings API roundtrip", async ({ request }) => {
+  // Get current settings
+  const getResponse = await request.get(`${API}/settings/image-save`);
+  const original = await getResponse.json();
+
+  // Update with modified settings
+  const modified = { ...original, filenamePrefix: "e2e-test" };
+  const putResponse = await request.put(`${API}/settings/image-save`, {
+    data: modified,
+  });
+  expect(putResponse.ok()).toBeTruthy();
+
+  // Verify the change persisted
+  const verifyResponse = await request.get(`${API}/settings/image-save`);
+  const verified = await verifyResponse.json();
+  expect(verified.filenamePrefix).toBe("e2e-test");
+
+  // Restore original settings
+  await request.put(`${API}/settings/image-save`, { data: original });
+});


### PR DESCRIPTION
## Summary
- Hardware trigger support: Soft/Hard/Combined trigger mode selector in UI, passed to acquisition start API
- Acquisition presets: save/load named sets of acquisition settings (profile, trigger mode, frame count, interval)
- E2E Playwright tests for camera settings tab and image save settings

## New Files
- `Services/AcquisitionPreset.cs`, `Services/AcquisitionPresetService.cs` -- preset model + JSON persistence
- `Controllers/PresetController.cs` -- REST CRUD for presets
- `components/PresetSelector.tsx` -- save/load preset dialogs
- `tests/camera-settings.spec.ts` -- 4 E2E tests for camera settings
- `tests/image-save-settings.spec.ts` -- 6 E2E tests for image save settings

## Test plan
- [x] `dotnet test` -- 154 + 198 all passing
- [x] `npm run build` -- clean build
- [ ] Manual: select Hard trigger, start acquisition, verify API receives triggerMode=hard
- [ ] Manual: save a preset, close app, reload, load preset, verify settings restored
- [ ] E2E: `npx playwright test` (requires running backend + frontend dev servers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)