### PR TITLE
feat: split continuous mode into Auto and Manual sub-modes

### DIFF
--- a/src/PeanutVision.Api/Program.cs
+++ b/src/PeanutVision.Api/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins("http://localhost:5173", "http://localhost:3000")
+        policy.WithOrigins("http://localhost:5173", "http://localhost:5174", "http://localhost:3000")
               .AllowAnyHeader()
               .AllowAnyMethod();
     });

--- a/src/peanut-vision-ui/src/api/types.ts
+++ b/src/peanut-vision-ui/src/api/types.ts
@@ -62,6 +62,7 @@ export type AcquisitionAction = "start" | "stop" | "trigger" | "snapshot";
 export type ChannelState = "none" | "idle" | "active";
 
 export type AcquisitionMode = "single" | "continuous";
+export type ContinuousSubMode = "auto" | "manual";
 
 export interface AcquisitionStatus {
   isActive: boolean;

--- a/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
@@ -15,7 +15,7 @@ import AdjustIcon from "@mui/icons-material/Adjust";
 import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import StatusChip from "./StatusChip";
-import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, CamFileInfo } from "../api/types";
+import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, CamFileInfo, ContinuousSubMode } from "../api/types";
 
 interface Props {
   cameras: CamFileInfo[];
@@ -23,6 +23,7 @@ interface Props {
   onProfileChange: (id: string) => void;
   mode: AcquisitionMode;
   onModeChange: (mode: AcquisitionMode) => void;
+  continuousSubMode: ContinuousSubMode;
   status: AcquisitionStatus | null;
   busy: boolean;
   onCapture: () => void;
@@ -41,6 +42,7 @@ export default function AcquisitionControls({
   onProfileChange,
   mode,
   onModeChange,
+  continuousSubMode,
   status,
   busy,
   onCapture,
@@ -142,9 +144,9 @@ export default function AcquisitionControls({
               </span>
             </Tooltip>
           )}
-          {allowed("trigger") && (
+          {allowed("trigger") && continuousSubMode === "manual" && (
             <Tooltip
-              title={busy ? "처리 중..." : "프레임 촬영"}
+              title={busy ? "처리 중..." : "수동 촬영 (Manual capture)"}
             >
               <span>
                 <Button

--- a/src/peanut-vision-ui/src/components/ContinuousSettings.tsx
+++ b/src/peanut-vision-ui/src/components/ContinuousSettings.tsx
@@ -3,8 +3,13 @@ import Box from "@mui/material/Box";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import type { ContinuousSubMode } from "../api/types";
 
 interface Props {
+  subMode: ContinuousSubMode;
+  onSubModeChange: (value: ContinuousSubMode) => void;
   frameCount: number | null;
   onFrameCountChange: (value: number | null) => void;
   intervalMs: number | null;
@@ -13,6 +18,8 @@ interface Props {
 }
 
 export default function ContinuousSettings({
+  subMode,
+  onSubModeChange,
   frameCount,
   onFrameCountChange,
   intervalMs,
@@ -28,6 +35,17 @@ export default function ContinuousSettings({
 
   return (
     <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+      <ToggleButtonGroup
+        value={subMode}
+        exclusive
+        onChange={(_, v) => v && onSubModeChange(v)}
+        size="small"
+        disabled={disabled}
+      >
+        <ToggleButton value="auto">Auto</ToggleButton>
+        <ToggleButton value="manual">Manual</ToggleButton>
+      </ToggleButtonGroup>
+
       <TextField
         label="Frame Count"
         type="number"
@@ -52,20 +70,23 @@ export default function ContinuousSettings({
         }
         label="Infinite"
       />
-      <TextField
-        label="Interval (ms)"
-        type="number"
-        size="small"
-        value={intervalMs ?? ""}
-        onChange={(e) => {
-          const v = parseInt(e.target.value, 10);
-          onIntervalMsChange(isNaN(v) || v < 0 ? null : v);
-        }}
-        disabled={disabled}
-        helperText="최소 50ms"
-        slotProps={{ htmlInput: { min: 50 } }}
-        sx={{ width: 130 }}
-      />
+
+      {subMode === "auto" && (
+        <TextField
+          label="Interval (ms)"
+          type="number"
+          size="small"
+          value={intervalMs ?? ""}
+          onChange={(e) => {
+            const v = parseInt(e.target.value, 10);
+            onIntervalMsChange(isNaN(v) || v < 0 ? null : v);
+          }}
+          disabled={disabled}
+          helperText="최소 50ms"
+          slotProps={{ htmlInput: { min: 50 } }}
+          sx={{ width: 130 }}
+        />
+      )}
     </Box>
   );
 }

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -19,7 +19,7 @@ import ImageSaveSettingsPanel from "../components/ImageSaveSettingsPanel";
 import SessionSelector from "../components/SessionSelector";
 import CalibrationActions from "../components/CalibrationActions";
 import ExposureControl from "../components/ExposureControl";
-import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage, ExposureInfo } from "../api/types";
+import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, CapturedImage, ContinuousSubMode, ExposureInfo } from "../api/types";
 import {
   getCameras,
   startAcquisition,
@@ -51,6 +51,7 @@ export default function AcquisitionTab() {
   const [cameras, setCameras] = useState<CamFileInfo[]>([]);
   const [selectedProfile, setSelectedProfile] = useState("");
   const [mode, setMode] = useState<AcquisitionMode>("single");
+  const [continuousSubMode, setContinuousSubMode] = useState<ContinuousSubMode>("auto");
   const [frameCount, setFrameCount] = useState<number | null>(null);
   const [intervalMs, setIntervalMs] = useState<number | null>(null);
   const [status, setStatus] = useState<AcquisitionStatus | null>(null);
@@ -145,7 +146,12 @@ export default function AcquisitionTab() {
 
   const handleStart = () =>
     execute(async () => {
-      await startAcquisition(selectedProfile, undefined, frameCount, intervalMs);
+      await startAcquisition(
+        selectedProfile,
+        undefined,
+        frameCount,
+        continuousSubMode === "auto" ? intervalMs : null,
+      );
       fetchStatus();
       setSnackbar({ message: "촬영이 시작되었습니다", severity: "success" });
     });
@@ -230,6 +236,7 @@ export default function AcquisitionTab() {
         onProfileChange={setSelectedProfile}
         mode={mode}
         onModeChange={setMode}
+        continuousSubMode={continuousSubMode}
         status={status}
         busy={busy}
         onCapture={handleCapture}
@@ -244,6 +251,8 @@ export default function AcquisitionTab() {
 
       {mode === "continuous" && (
         <ContinuousSettings
+          subMode={continuousSubMode}
+          onSubModeChange={setContinuousSubMode}
           frameCount={frameCount}
           onFrameCountChange={setFrameCount}
           intervalMs={intervalMs}

--- a/src/peanut-vision-ui/tests/acquisition-tab.spec.ts
+++ b/src/peanut-vision-ui/tests/acquisition-tab.spec.ts
@@ -101,11 +101,12 @@ test("allowedActions disables buttons correctly", async ({ page }) => {
     timeout: 10_000,
   });
 
-  // Switch to continuous mode and start
+  // Switch to continuous mode, then select Manual sub-mode so Trigger is shown
   await page.getByRole("button", { name: /^continuous$/i }).click();
+  await page.getByRole("button", { name: /^manual$/i }).click();
   await page.getByRole("button", { name: /^start$/i }).click();
 
-  // After start: Stop and Trigger should be visible
+  // After start in Manual mode: Stop and Trigger should both be visible
   await expect(page.getByRole("button", { name: /^stop$/i })).toBeVisible({
     timeout: 10_000,
   });
@@ -113,4 +114,65 @@ test("allowedActions disables buttons correctly", async ({ page }) => {
   await page.screenshot({
     path: "test-results/06-allowed-actions-active.png",
   });
+});
+
+test("ContinuousSettings: Auto/Manual toggle renders both options", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: /^continuous$/i }).click();
+
+  // Both toggle buttons must be present in ContinuousSettings
+  await expect(page.getByRole("button", { name: /^auto$/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /^manual$/i })).toBeVisible();
+  await page.screenshot({ path: "test-results/07-submode-toggle.png" });
+});
+
+test("ContinuousSettings: Interval field hidden in Manual sub-mode", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: /^continuous$/i }).click();
+
+  // Default is Auto — Interval field should be visible
+  await expect(page.locator("label", { hasText: "Interval (ms)" })).toBeVisible();
+
+  // Switch to Manual — Interval field must disappear
+  await page.getByRole("button", { name: /^manual$/i }).click();
+  await expect(
+    page.locator("label", { hasText: "Interval (ms)" })
+  ).not.toBeVisible();
+  await page.screenshot({ path: "test-results/08-manual-no-interval.png" });
+});
+
+test("ContinuousSettings: Trigger hidden in Auto, visible in Manual while active", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: /^continuous$/i }).click();
+
+  // Start in Auto sub-mode (default)
+  await expect(page.getByRole("button", { name: /^start$/i })).toBeEnabled({
+    timeout: 10_000,
+  });
+  await page.getByRole("button", { name: /^start$/i }).click();
+  await expect(page.getByRole("button", { name: /^stop$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Trigger button must NOT appear in Auto mode
+  await expect(
+    page.getByRole("button", { name: /trigger/i })
+  ).not.toBeVisible();
+  await page.screenshot({ path: "test-results/09-auto-no-trigger.png" });
+
+  // Stop, switch to Manual, restart — Trigger must appear
+  await page.getByRole("button", { name: /^stop$/i }).click();
+  await expect(page.getByRole("button", { name: /^start$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByRole("button", { name: /^manual$/i }).click();
+  await page.getByRole("button", { name: /^start$/i }).click();
+  await expect(page.getByRole("button", { name: /^stop$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByRole("button", { name: /trigger/i })).toBeVisible();
+  await page.screenshot({ path: "test-results/10-manual-trigger-visible.png" });
 });


### PR DESCRIPTION
Closes #40

## Summary

- **Auto** sub-mode: frames captured automatically at the configured interval (existing behaviour, now explicitly labelled)
- **Manual** sub-mode: channel stays active, operator presses Trigger for each frame — no interval timer, Interval field hidden
- Shared `busy` state disables buttons correctly across both sub-modes

## Changes

| File | Change |
|---|---|
| `api/types.ts` | Add `ContinuousSubMode = "auto" \| "manual"` |
| `ContinuousSettings.tsx` | Auto/Manual `ToggleButtonGroup`; Interval field hidden in Manual |
| `AcquisitionControls.tsx` | Trigger button only shown in Manual sub-mode while active |
| `AcquisitionTab.tsx` | `continuousSubMode` state; `handleStart` omits `intervalMs` in Manual |
| `acquisition-tab.spec.ts` | 3 new Playwright tests for toggle, interval visibility, Trigger visibility |

## Test plan

- [ ] Switch to Continuous → Auto sub-mode selected by default, Interval field visible
- [ ] Switch to Manual sub-mode → Interval field hidden
- [ ] Start in Auto → Trigger button absent, frames fire automatically
- [ ] Start in Manual → Trigger button visible, frame captured only on press
- [ ] All 9 Playwright e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)