### PR TITLE
fix: auto-save images during continuous mode (GET /latest-frame)

### DIFF
--- a/src/PeanutVision.Api.Tests/Specs/Acquisition/AcquisitionLatestFrameSpec.cs
+++ b/src/PeanutVision.Api.Tests/Specs/Acquisition/AcquisitionLatestFrameSpec.cs
@@ -49,4 +49,24 @@ public class AcquisitionLatestFrameSpec : IClassFixture<PeanutVisionApiFactory>,
         Assert.Equal((byte)'N', bytes[2]);
         Assert.Equal((byte)'G', bytes[3]);
     }
+
+    [Fact]
+    public async Task LatestFrame_with_autosave_sets_image_path_header_on_first_poll()
+    {
+        await _client.PostJsonAsync("/api/acquisition/start",
+            new { profileId = "crevis-tc-a160k-softtrig-rgb8.cam" });
+        await _client.PostAsync("/api/acquisition/trigger", null);
+
+        // First poll — new frame, should auto-save
+        var first = await _client.GetAsync("/api/acquisition/latest-frame");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.True(first.Headers.Contains("X-Image-Path"),
+            "First poll of a new frame should set X-Image-Path");
+
+        // Second poll — same frame reference, should NOT save again
+        var second = await _client.GetAsync("/api/acquisition/latest-frame");
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.False(second.Headers.Contains("X-Image-Path"),
+            "Second poll of the same frame must not set X-Image-Path (no duplicate save)");
+    }
 }

--- a/src/PeanutVision.Api/Controllers/AcquisitionController.cs
+++ b/src/PeanutVision.Api/Controllers/AcquisitionController.cs
@@ -12,17 +12,20 @@ public class AcquisitionController : ControllerBase
     private readonly IAcquisitionService _acquisition;
     private readonly IImageSaveSettingsService _saveSettings;
     private readonly FilenameGenerator _filenameGenerator;
+    private readonly FrameSaveTracker _frameSaveTracker;
     private readonly string _contentRootPath;
 
     public AcquisitionController(
         IAcquisitionService acquisition,
         IImageSaveSettingsService saveSettings,
         FilenameGenerator filenameGenerator,
+        FrameSaveTracker frameSaveTracker,
         IWebHostEnvironment environment)
     {
         _acquisition = acquisition;
         _saveSettings = saveSettings;
         _filenameGenerator = filenameGenerator;
+        _frameSaveTracker = frameSaveTracker;
         _contentRootPath = environment.ContentRootPath;
     }
 
@@ -153,6 +156,15 @@ public class AcquisitionController : ControllerBase
         var frame = _acquisition.GetLatestFrame();
         if (frame is null)
             return NoContent();
+
+        var settings = _saveSettings.GetSettings();
+        if (settings.AutoSave && _frameSaveTracker.ShouldSave(frame))
+        {
+            var filePath = _filenameGenerator.Generate(
+                settings, _contentRootPath, _acquisition.ActiveProfileId?.Value);
+            new ImageWriter().Save(frame, filePath);
+            Response.Headers["X-Image-Path"] = filePath;
+        }
 
         var encoder = new PngEncoder();
         var stream = new MemoryStream();

--- a/src/PeanutVision.Api/Program.cs
+++ b/src/PeanutVision.Api/Program.cs
@@ -40,6 +40,7 @@ else
 var saveSettingsPath = Path.Combine(builder.Environment.ContentRootPath, "image-save-settings.json");
 builder.Services.AddSingleton<IImageSaveSettingsService>(new ImageSaveSettingsService(saveSettingsPath));
 builder.Services.AddSingleton<FilenameGenerator>();
+builder.Services.AddSingleton<FrameSaveTracker>();
 
 var dbPath = Path.Combine(builder.Environment.ContentRootPath, "peanut-vision.db");
 builder.Services.AddDbContext<AppDbContext>(options =>

--- a/src/PeanutVision.Api/Services/FrameSaveTracker.cs
+++ b/src/PeanutVision.Api/Services/FrameSaveTracker.cs
@@ -1,0 +1,23 @@
+using PeanutVision.MultiCamDriver.Imaging;
+
+namespace PeanutVision.Api.Services;
+
+/// <summary>
+/// Tracks which ImageData instance was last saved to disk.
+/// Prevents the same frame from being saved multiple times when
+/// GET /latest-frame is polled faster than frames arrive.
+/// </summary>
+public sealed class FrameSaveTracker
+{
+    private volatile ImageData? _lastSaved;
+
+    /// <summary>
+    /// Returns true (and records the frame as saved) only if this frame
+    /// has not been saved before. Safe for concurrent callers.
+    /// </summary>
+    public bool ShouldSave(ImageData frame)
+    {
+        var previous = Interlocked.Exchange(ref _lastSaved, frame);
+        return !ReferenceEquals(previous, frame);
+    }
+}

--- a/src/peanut-vision-ui/src/api/client.ts
+++ b/src/peanut-vision-ui/src/api/client.ts
@@ -93,11 +93,12 @@ export async function snapshot(
   return { blob: await res.blob(), savedPath };
 }
 
-export async function getLatestFrame(): Promise<Blob | null> {
+export async function getLatestFrame(): Promise<CaptureResult | null> {
   const res = await fetch(`${API_BASE_URL}/acquisition/latest-frame`);
   if (res.status === 204) return null;
   if (!res.ok) await handleErrorResponse(res);
-  return res.blob();
+  const savedPath = res.headers.get("X-Image-Path") ?? undefined;
+  return { blob: await res.blob(), savedPath };
 }
 
 // ── Settings ──

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -134,8 +134,8 @@ export default function AcquisitionTab() {
     if (!status?.isActive || !status?.hasFrame) return;
     const t = setInterval(async () => {
       try {
-        const blob = await getLatestFrame();
-        if (blob) addImage(blob);
+        const result = await getLatestFrame();
+        if (result) addImage(result.blob, result.savedPath);
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Bug

Images were **not saved to disk during continuous mode**.

`POST /trigger` and `POST /snapshot` both had `AutoSave` logic, but `GET /latest-frame` — the endpoint polled every second during continuous acquisition — had none. Frames appeared in the UI gallery but nothing landed on the filesystem.

## Root cause

```
Continuous mode flow:
  Start()  →  frames arrive via callback  →  stored in _lastFrame
  UI polls GET /latest-frame every 1s    →  ← no save here  ❌
```

A secondary problem: even if we naively added save logic, the same `ImageData` reference stays in `_lastFrame` between frames. Saving on every poll would write duplicate files until a new frame arrives.

## Fix

**`FrameSaveTracker` singleton** — tracks the last saved `ImageData` by reference. Uses `Interlocked.Exchange` for thread safety. Returns `true` only when the frame reference is new.

```csharp
// saves once per unique frame, regardless of poll frequency
if (settings.AutoSave && _frameSaveTracker.ShouldSave(frame))
{
    var filePath = _filenameGenerator.Generate(...);
    new ImageWriter().Save(frame, filePath);
    Response.Headers["X-Image-Path"] = filePath;
}
```

**Frontend**: `getLatestFrame()` now returns `CaptureResult | null` (same shape as `triggerAndCapture` / `snapshot`), so `savedPath` flows through to `ImageViewer` during live preview.

## Tests

New regression test: `LatestFrame_with_autosave_sets_image_path_header_on_first_poll`
- First poll after a new frame → `X-Image-Path` header present ✅
- Second poll of the same frame → no header, no duplicate save ✅

**165 API tests passing (was 164), 198 driver tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)