### PR TITLE
refactor: move Captures and Event Log to right panel

### DIFF
--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import Chip from "@mui/material/Chip";
@@ -115,8 +115,48 @@ interface Props {
   onSessionChange?: (name: string | null) => void;
 }
 
+const RIGHT_PANEL_MIN = 200;
+const RIGHT_PANEL_MAX = 560;
+const RIGHT_PANEL_DEFAULT = 280;
+
 export default function AcquisitionTab({ onSessionChange }: Props = {}) {
   const [cameras, setCameras] = useState<CamFileInfo[]>([]);
+
+  // Right panel resize — width stored in a ref and applied via DOM ref
+  // to avoid re-renders (and layout shifts) during dragging
+  const rightPanelRef = useRef<HTMLDivElement>(null);
+  const rightPanelWidth = useRef(RIGHT_PANEL_DEFAULT);
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(0);
+
+  const onResizerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    dragStartX.current = e.clientX;
+    dragStartWidth.current = rightPanelWidth.current;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDragging.current) return;
+      const delta = dragStartX.current - ev.clientX;
+      const next = Math.min(RIGHT_PANEL_MAX, Math.max(RIGHT_PANEL_MIN, dragStartWidth.current + delta));
+      rightPanelWidth.current = next;
+      if (rightPanelRef.current) rightPanelRef.current.style.width = `${next}px`;
+    };
+
+    const onMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, []);
   const [selectedProfile, setSelectedProfile] = useState("");
   const [mode, setMode] = useState<AcquisitionMode>("single");
   const [continuousSubMode, setContinuousSubMode] = useState<ContinuousSubMode>("auto");
@@ -416,13 +456,25 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
         </Box>
       </Box>
 
+      {/* DRAG HANDLE */}
+      <Box
+        onMouseDown={onResizerMouseDown}
+        sx={{
+          width: 4,
+          flexShrink: 0,
+          cursor: "col-resize",
+          bgcolor: "divider",
+          transition: "background-color 0.15s",
+          "&:hover": { bgcolor: "primary.main" },
+        }}
+      />
+
       {/* RIGHT PANEL */}
       <Box
+        ref={rightPanelRef}
         sx={{
-          width: 280,
+          width: RIGHT_PANEL_DEFAULT,
           flexShrink: 0,
-          borderLeft: "1px solid",
-          borderColor: "divider",
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",


### PR DESCRIPTION
## Summary

- Move the **Captures** (gallery) and **Event Log** collapsible panels from the bottom of the main canvas into a fixed **280px right sidebar**
- The center column now contains only the image viewer and the histogram/stats row, giving the live view more vertical space
- Both panels retain their collapsible behavior (Captures open by default, Event Log collapsed)

## Layout after this change

```
┌─────────────┬──────────────────────────────┬──────────────┐
│ LEFT        │ MAIN CANVAS                  │ RIGHT        │
│ SIDEBAR     │                              │ PANEL        │
│ (controls)  │  ImageViewer (flex-grow)     │  [Captures ▼]│
│             │                              │  [img][img]… │
│             │  Histogram | Stats           │              │
│             │                              │  [Event Log▼]│
└─────────────┴──────────────────────────────┴──────────────┘
```

## Test plan

- [ ] Acquisition tab renders three columns: left sidebar / center canvas / right panel
- [ ] Right panel shows Captures header with image count badge; thumbnails appear after capture
- [ ] Event Log header is collapsed by default; expands on click
- [ ] Image viewer and histogram/stats occupy the full center column height
- [ ] `npx playwright test` — existing E2E specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)