### PR TITLE
feat: acquisition UI — tab sidebar, canvas preview, resizable panels

### DIFF
--- a/src/peanut-vision-ui/src/components/AcquisitionActionBar.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionActionBar.tsx
@@ -1,0 +1,147 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import StopIcon from "@mui/icons-material/Stop";
+import AdjustIcon from "@mui/icons-material/Adjust";
+import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import StatusChip from "./StatusChip";
+import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, ContinuousSubMode } from "../api/types";
+
+/** Renders capture/start/stop/trigger buttons and status indicator. */
+interface Props {
+  mode: AcquisitionMode;
+  continuousSubMode: ContinuousSubMode;
+  selectedProfile: string;
+  status: AcquisitionStatus | null;
+  busy: boolean;
+  onCapture: () => void;
+  onStart: () => void;
+  onStop: () => void;
+  onTrigger: () => void;
+  onRefresh: () => void;
+  refreshThrottled: boolean;
+  hasWarnings?: boolean;
+  hasErrors?: boolean;
+}
+
+export default function AcquisitionActionBar({
+  mode,
+  continuousSubMode,
+  selectedProfile,
+  status,
+  busy,
+  onCapture,
+  onStart,
+  onStop,
+  onTrigger,
+  onRefresh,
+  refreshThrottled,
+  hasWarnings,
+  hasErrors,
+}: Props) {
+  const allowed = (action: AcquisitionAction) =>
+    status?.allowedActions?.includes(action) ?? false;
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+      {mode === "single" ? (
+        <Tooltip
+          title={
+            busy || !allowed("snapshot") || !selectedProfile
+              ? "촬영 중에는 스냅샷을 찍을 수 없습니다"
+              : "단일 촬영"
+          }
+        >
+          <span>
+            <Button
+              variant="contained"
+              startIcon={<PhotoCameraIcon />}
+              onClick={onCapture}
+              disabled={busy || !allowed("snapshot") || !selectedProfile}
+            >
+              Capture
+            </Button>
+          </span>
+        </Tooltip>
+      ) : (
+        <ButtonGroup variant="contained">
+          {allowed("stop") ? (
+            <Tooltip title={busy ? "처리 중..." : "촬영 중지"}>
+              <span>
+                <Button
+                  color="error"
+                  startIcon={<StopIcon />}
+                  onClick={onStop}
+                  disabled={busy}
+                >
+                  Stop
+                </Button>
+              </span>
+            </Tooltip>
+          ) : (
+            <Tooltip
+              title={
+                !selectedProfile
+                  ? "프로파일을 선택하세요"
+                  : busy
+                  ? "처리 중..."
+                  : !allowed("start")
+                  ? "시작할 수 없습니다"
+                  : "연속 촬영 시작"
+              }
+            >
+              <span>
+                <Button
+                  color="success"
+                  startIcon={<PlayArrowIcon />}
+                  onClick={onStart}
+                  disabled={busy || !allowed("start") || !selectedProfile}
+                >
+                  Start
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+          {allowed("trigger") && continuousSubMode === "manual" && (
+            <Tooltip title={busy ? "처리 중..." : "수동 촬영 (Manual capture)"}>
+              <span>
+                <Button
+                  startIcon={<AdjustIcon />}
+                  onClick={onTrigger}
+                  disabled={busy}
+                >
+                  Trigger
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+        </ButtonGroup>
+      )}
+
+      {status && (
+        <StatusChip
+          active={status.isActive}
+          label={status.isActive ? `Active (${status.profileId ?? ""})` : "Inactive"}
+          hasWarnings={hasWarnings}
+          hasErrors={hasErrors}
+        />
+      )}
+
+      <Tooltip title={refreshThrottled ? "Wait..." : "Refresh status"}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={onRefresh}
+            disabled={refreshThrottled}
+          >
+            <RefreshIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionControls.tsx
@@ -1,22 +1,10 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
-import FormControl from "@mui/material/FormControl";
-import IconButton from "@mui/material/IconButton";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import Tooltip from "@mui/material/Tooltip";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import StopIcon from "@mui/icons-material/Stop";
-import AdjustIcon from "@mui/icons-material/Adjust";
-import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import StatusChip from "./StatusChip";
-import type { AcquisitionAction, AcquisitionMode, AcquisitionStatus, CamFileInfo, ContinuousSubMode, TriggerModeOption } from "../api/types";
+import CameraProfileSelector from "./CameraProfileSelector";
+import AcquisitionModeSelector from "./AcquisitionModeSelector";
+import AcquisitionActionBar from "./AcquisitionActionBar";
+import type { AcquisitionMode, AcquisitionStatus, CamFileInfo, ContinuousSubMode, TriggerModeOption } from "../api/types";
 
+/** Thin wrapper composing camera profile, mode/trigger selection, and action buttons. */
 interface Props {
   cameras: CamFileInfo[];
   selectedProfile: string;
@@ -58,148 +46,38 @@ export default function AcquisitionControls({
   hasWarnings,
   hasErrors,
 }: Props) {
-  const allowed = (action: AcquisitionAction) =>
-    status?.allowedActions?.includes(action) ?? false;
-
   return (
-    <Box sx={{ display: "flex", gap: 2, alignItems: "flex-end", flexWrap: "wrap" }}>
-      <FormControl size="small" sx={{ minWidth: 280 }}>
-        <InputLabel>Camera Profile</InputLabel>
-        <Select
-          value={selectedProfile}
-          label="Camera Profile"
-          onChange={(e) => onProfileChange(e.target.value)}
-          disabled={status?.isActive}
-        >
-          {cameras.map((c) => (
-            <MenuItem key={c.fileName} value={c.fileName}>
-              {c.fileName}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-
-      <ToggleButtonGroup
-        value={mode}
-        exclusive
-        onChange={(_, v) => v && onModeChange(v)}
-        size="small"
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <CameraProfileSelector
+        cameras={cameras}
+        selectedProfile={selectedProfile}
+        onProfileChange={onProfileChange}
         disabled={status?.isActive}
-      >
-        <ToggleButton value="single">Single</ToggleButton>
-        <ToggleButton value="continuous">Continuous</ToggleButton>
-      </ToggleButtonGroup>
+      />
 
-      <FormControl size="small" sx={{ minWidth: 120 }}>
-        <InputLabel>Trigger</InputLabel>
-        <Select
-          value={triggerMode}
-          label="Trigger"
-          onChange={(e) => onTriggerModeChange(e.target.value as TriggerModeOption)}
-          disabled={status?.isActive}
-        >
-          <MenuItem value="soft">Soft</MenuItem>
-          <MenuItem value="hard">Hard</MenuItem>
-          <MenuItem value="combined">Combined</MenuItem>
-        </Select>
-      </FormControl>
+      <AcquisitionModeSelector
+        mode={mode}
+        onModeChange={onModeChange}
+        triggerMode={triggerMode}
+        onTriggerModeChange={onTriggerModeChange}
+        disabled={status?.isActive}
+      />
 
-      {mode === "single" ? (
-        <Tooltip
-          title={
-            busy || !allowed("snapshot") || !selectedProfile
-              ? "촬영 중에는 스냅샷을 찍을 수 없습니다"
-              : "단일 촬영"
-          }
-        >
-          <span>
-            <Button
-              variant="contained"
-              startIcon={<PhotoCameraIcon />}
-              onClick={onCapture}
-              disabled={busy || !allowed("snapshot") || !selectedProfile}
-            >
-              Capture
-            </Button>
-          </span>
-        </Tooltip>
-      ) : (
-        <ButtonGroup variant="contained">
-          {allowed("stop") ? (
-            <Tooltip title={busy ? "처리 중..." : "촬영 중지"}>
-              <span>
-                <Button
-                  color="error"
-                  startIcon={<StopIcon />}
-                  onClick={onStop}
-                  disabled={busy}
-                >
-                  Stop
-                </Button>
-              </span>
-            </Tooltip>
-          ) : (
-            <Tooltip
-              title={
-                !selectedProfile
-                  ? "프로파일을 선택하세요"
-                  : busy
-                  ? "처리 중..."
-                  : !allowed("start")
-                  ? "시작할 수 없습니다"
-                  : "연속 촬영 시작"
-              }
-            >
-              <span>
-                <Button
-                  color="success"
-                  startIcon={<PlayArrowIcon />}
-                  onClick={onStart}
-                  disabled={busy || !allowed("start") || !selectedProfile}
-                >
-                  Start
-                </Button>
-              </span>
-            </Tooltip>
-          )}
-          {allowed("trigger") && continuousSubMode === "manual" && (
-            <Tooltip
-              title={busy ? "처리 중..." : "수동 촬영 (Manual capture)"}
-            >
-              <span>
-                <Button
-                  startIcon={<AdjustIcon />}
-                  onClick={onTrigger}
-                  disabled={busy}
-                >
-                  Trigger
-                </Button>
-              </span>
-            </Tooltip>
-          )}
-        </ButtonGroup>
-      )}
-
-      {status && (
-        <StatusChip
-          active={status.isActive}
-          label={status.isActive ? `Active (${status.profileId ?? ""})` : "Inactive"}
-          hasWarnings={hasWarnings}
-          hasErrors={hasErrors}
-        />
-      )}
-
-      <Tooltip title={refreshThrottled ? "Wait..." : "Refresh status"}>
-        <span>
-          <IconButton
-            size="small"
-            onClick={onRefresh}
-            disabled={refreshThrottled}
-          >
-            <RefreshIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+      <AcquisitionActionBar
+        mode={mode}
+        continuousSubMode={continuousSubMode}
+        selectedProfile={selectedProfile}
+        status={status}
+        busy={busy}
+        onCapture={onCapture}
+        onStart={onStart}
+        onStop={onStop}
+        onTrigger={onTrigger}
+        onRefresh={onRefresh}
+        refreshThrottled={refreshThrottled}
+        hasWarnings={hasWarnings}
+        hasErrors={hasErrors}
+      />
     </Box>
   );
 }

--- a/src/peanut-vision-ui/src/components/AcquisitionModeSelector.tsx
+++ b/src/peanut-vision-ui/src/components/AcquisitionModeSelector.tsx
@@ -1,0 +1,54 @@
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import type { AcquisitionMode, TriggerModeOption } from "../api/types";
+
+/** Single/Continuous mode toggle paired with trigger mode selector. */
+interface Props {
+  mode: AcquisitionMode;
+  onModeChange: (mode: AcquisitionMode) => void;
+  triggerMode: TriggerModeOption;
+  onTriggerModeChange: (mode: TriggerModeOption) => void;
+  disabled?: boolean;
+}
+
+export default function AcquisitionModeSelector({
+  mode,
+  onModeChange,
+  triggerMode,
+  onTriggerModeChange,
+  disabled,
+}: Props) {
+  return (
+    <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+      <ToggleButtonGroup
+        value={mode}
+        exclusive
+        onChange={(_, v) => v && onModeChange(v)}
+        size="small"
+        disabled={disabled}
+      >
+        <ToggleButton value="single">Single</ToggleButton>
+        <ToggleButton value="continuous">Continuous</ToggleButton>
+      </ToggleButtonGroup>
+
+      <FormControl size="small" sx={{ flexGrow: 1 }}>
+        <InputLabel>Trigger</InputLabel>
+        <Select
+          value={triggerMode}
+          label="Trigger"
+          onChange={(e) => onTriggerModeChange(e.target.value as TriggerModeOption)}
+          disabled={disabled}
+        >
+          <MenuItem value="soft">Soft</MenuItem>
+          <MenuItem value="hard">Hard</MenuItem>
+          <MenuItem value="combined">Combined</MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/CalibrationActions.tsx
+++ b/src/peanut-vision-ui/src/components/CalibrationActions.tsx
@@ -29,27 +29,33 @@ export default function CalibrationActions({
         <Typography variant="subtitle2" gutterBottom>
           Calibration Actions
         </Typography>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
-          <Button variant="outlined" disabled={busy} onClick={onBlack}>
-            Black Calibration
-          </Button>
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
-            Cover the lens before executing
-          </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 1 }}>
+          <Box>
+            <Button variant="outlined" fullWidth disabled={busy} onClick={onBlack}>
+              Black Calibration
+            </Button>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5, px: 0.5 }}>
+              Cover the lens before executing
+            </Typography>
+          </Box>
 
-          <Button variant="outlined" disabled={busy} onClick={onWhite}>
-            White Calibration
-          </Button>
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
-            Ensure uniform ~200DN illumination
-          </Typography>
+          <Box>
+            <Button variant="outlined" fullWidth disabled={busy} onClick={onWhite}>
+              White Calibration
+            </Button>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5, px: 0.5 }}>
+              Ensure uniform ~200DN illumination
+            </Typography>
+          </Box>
 
-          <Button variant="outlined" disabled={busy} onClick={onWhiteBalance}>
-            White Balance (Once)
-          </Button>
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
-            Point lens at white target (~200DN)
-          </Typography>
+          <Box>
+            <Button variant="outlined" fullWidth disabled={busy} onClick={onWhiteBalance}>
+              White Balance (Once)
+            </Button>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5, px: 0.5 }}>
+              Point lens at white target (~200DN)
+            </Typography>
+          </Box>
 
           <FormControlLabel
             control={

--- a/src/peanut-vision-ui/src/components/CameraProfileSelector.tsx
+++ b/src/peanut-vision-ui/src/components/CameraProfileSelector.tsx
@@ -1,0 +1,33 @@
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import type { CamFileInfo } from "../api/types";
+
+/** Dropdown for selecting a camera profile (.cam file). */
+interface Props {
+  cameras: CamFileInfo[];
+  selectedProfile: string;
+  onProfileChange: (id: string) => void;
+  disabled?: boolean;
+}
+
+export default function CameraProfileSelector({ cameras, selectedProfile, onProfileChange, disabled }: Props) {
+  return (
+    <FormControl size="small" sx={{ minWidth: 280 }}>
+      <InputLabel>Camera Profile</InputLabel>
+      <Select
+        value={selectedProfile}
+        label="Camera Profile"
+        onChange={(event) => onProfileChange(event.target.value)}
+        disabled={disabled}
+      >
+        {cameras.map((camera) => (
+          <MenuItem key={camera.fileName} value={camera.fileName}>
+            {camera.fileName}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/peanut-vision-ui/src/components/CapturedImageList.tsx
+++ b/src/peanut-vision-ui/src/components/CapturedImageList.tsx
@@ -1,14 +1,11 @@
-import { useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
 import DeleteSweepIcon from "@mui/icons-material/DeleteSweep";
-import CloseIcon from "@mui/icons-material/Close";
 import DownloadIcon from "@mui/icons-material/Download";
-import JSZip from "jszip";
-import { saveAs } from "file-saver";
+import ImageThumbnail from "./ImageThumbnail";
+import { useImageExport } from "../hooks/useImageExport";
 import type { CapturedImage } from "../api/types";
 
 interface Props {
@@ -19,63 +16,26 @@ interface Props {
   onClear: () => void;
 }
 
-function formatTime(d: Date): string {
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
-}
-
-function formatFilename(d: Date, index: number): string {
-  return `capture_${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}_${formatTime(d).replace(/:/g, "")}_${String(index).padStart(3, "0")}.png`;
-}
-
 export default function CapturedImageList({ images, selectedId, onSelect, onDelete, onClear }: Props) {
-  const [exporting, setExporting] = useState(false);
-
-  const handleExportZip = async () => {
-    if (images.length === 0) return;
-    setExporting(true);
-    try {
-      const zip = new JSZip();
-      for (let i = 0; i < images.length; i++) {
-        const img = images[i];
-        zip.file(formatFilename(img.capturedAt, i + 1), img.blob);
-      }
-      const blob = await zip.generateAsync({ type: "blob" });
-      saveAs(blob, `captures_${new Date().toISOString().slice(0, 10)}.zip`);
-    } finally {
-      setExporting(false);
-    }
-  };
-
+  const { exporting, handleExportZip } = useImageExport(images);
 
   return (
-    <Box sx={{ mt: 1 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
-        <Typography variant="subtitle2" color="text.secondary">
-          Captured Images ({images.length})
-        </Typography>
-        <Box sx={{ display: "flex", gap: 0.5 }}>
-          {images.length > 0 && (
-            <>
-              <Button
-                size="small"
-                startIcon={exporting ? <CircularProgress size={14} /> : <DownloadIcon />}
-                onClick={handleExportZip}
-                disabled={exporting}
-              >
-                Export ZIP
-              </Button>
-              <Button
-                size="small"
-                color="error"
-                startIcon={<DeleteSweepIcon />}
-                onClick={onClear}
-              >
-                Clear All
-              </Button>
-            </>
-          )}
+    <Box>
+      {images.length > 0 && (
+        <Box sx={{ display: "flex", gap: 0.5, mb: 1, justifyContent: "flex-end" }}>
+          <Button
+            size="small"
+            startIcon={exporting ? <CircularProgress size={14} /> : <DownloadIcon />}
+            onClick={handleExportZip}
+            disabled={exporting}
+          >
+            Export ZIP
+          </Button>
+          <Button size="small" color="error" startIcon={<DeleteSweepIcon />} onClick={onClear}>
+            Clear All
+          </Button>
         </Box>
-      </Box>
+      )}
 
       {images.length === 0 ? (
         <Box
@@ -104,63 +64,14 @@ export default function CapturedImageList({ images, selectedId, onSelect, onDele
             "&::-webkit-scrollbar-thumb": { borderRadius: 2, bgcolor: "divider" },
           }}
         >
-          {images.map((img) => (
-            <Box
-              key={img.id}
-              onClick={() => onSelect(img.id)}
-              sx={{
-                flexShrink: 0,
-                cursor: "pointer",
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <Box
-                sx={{
-                  position: "relative",
-                  width: 120,
-                  height: 90,
-                  border: "2px solid",
-                  borderColor: img.id === selectedId ? "primary.main" : "divider",
-                  borderRadius: 1,
-                  overflow: "hidden",
-                  transition: "border-color 0.15s",
-                  "&:hover .delete-btn": { opacity: 1 },
-                }}
-              >
-                <img
-                  src={img.url}
-                  alt={`Capture at ${formatTime(img.capturedAt)}`}
-                  style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
-                />
-                <IconButton
-                  className="delete-btn"
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(img.id);
-                  }}
-                  sx={{
-                    position: "absolute",
-                    top: -2,
-                    right: -2,
-                    opacity: 0,
-                    transition: "opacity 0.15s",
-                    p: 0.25,
-                    bgcolor: "rgba(0,0,0,0.6)",
-                    color: "white",
-                    "&:hover": { bgcolor: "error.main" },
-                  }}
-                >
-                  <CloseIcon sx={{ fontSize: 14 }} />
-                </IconButton>
-              </Box>
-              <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.65rem" }}>
-                {formatTime(img.capturedAt)}
-              </Typography>
-            </Box>
+          {images.map((image) => (
+            <ImageThumbnail
+              key={image.id}
+              image={image}
+              selected={image.id === selectedId}
+              onSelect={onSelect}
+              onDelete={onDelete}
+            />
           ))}
         </Box>
       )}

--- a/src/peanut-vision-ui/src/components/DetailImageViewDialog.tsx
+++ b/src/peanut-vision-ui/src/components/DetailImageViewDialog.tsx
@@ -1,0 +1,71 @@
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import CloseIcon from "@mui/icons-material/Close";
+import ImageActionBar from "./ImageActionBar";
+import type { CapturedImage } from "../api/types";
+import { formatFilenameTimestamp, formatTime } from "../utils/formatTimestamp";
+
+/** Full-size image dialog opened when a gallery thumbnail is clicked. */
+interface Props {
+  image: CapturedImage | null;
+  errorMessage?: string | null;
+  onClose: () => void;
+}
+
+export default function DetailImageViewDialog({ image, errorMessage, onClose }: Props) {
+  return (
+    <Dialog open={image !== null} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pb: 1 }}>
+        <Typography variant="subtitle1" fontWeight={600}>
+          {image ? formatTime(image.capturedAt) : ""}
+        </Typography>
+        <IconButton size="small" onClick={onClose}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ p: 1.5, display: "flex", flexDirection: "column", gap: 1 }}>
+        <Box
+          sx={{
+            position: "relative",
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            overflow: "hidden",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bgcolor: "background.default",
+            minHeight: 400,
+          }}
+        >
+          {image && (
+            <img
+              src={image.url}
+              alt="Captured frame"
+              style={{ maxWidth: "100%", maxHeight: "70vh", display: "block", objectFit: "contain" }}
+            />
+          )}
+          {errorMessage && (
+            <Box sx={{ position: "absolute", top: 8, left: 8 }}>
+              <Chip size="small" label={errorMessage} color="error" sx={{ fontWeight: 600, fontSize: "0.7rem" }} />
+            </Box>
+          )}
+        </Box>
+
+        {image && (
+          <ImageActionBar
+            url={image.url}
+            filename={`capture-${formatFilenameTimestamp(image.capturedAt)}.png`}
+            savedPath={image.savedPath}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ExposureControl.tsx
+++ b/src/peanut-vision-ui/src/components/ExposureControl.tsx
@@ -35,14 +35,14 @@ export default function ExposureControl({
   return (
     <Card variant="outlined">
       <CardContent>
-        <Box sx={{ display: "flex", justifyContent: "space-between", mb: 2 }}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1.5 }}>
           <Typography variant="subtitle2">Exposure &amp; Gain</Typography>
           <Button size="small" variant="text" onClick={onLoad} disabled={busy}>
             Load Current
           </Button>
         </Box>
 
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <Box>
             <Typography variant="body2" gutterBottom>
               Exposure ({exposureValue.toFixed(0)} &micro;s)

--- a/src/peanut-vision-ui/src/components/ImageActionBar.tsx
+++ b/src/peanut-vision-ui/src/components/ImageActionBar.tsx
@@ -1,0 +1,43 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import DownloadIcon from "@mui/icons-material/Download";
+import SaveIcon from "@mui/icons-material/Save";
+
+/** Renders a download button and optional saved-path indicator for a captured image. */
+interface Props {
+  url: string;
+  filename?: string;
+  savedPath?: string;
+}
+
+export default function ImageActionBar({ url, filename, savedPath }: Props) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+      <Button
+        size="small"
+        startIcon={<DownloadIcon />}
+        href={url}
+        download={filename ?? `capture-${Date.now()}.png`}
+      >
+        Download
+      </Button>
+      {savedPath && (
+        <Tooltip title={savedPath}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0 }}>
+            <SaveIcon sx={{ fontSize: 14, color: "success.main", flexShrink: 0 }} />
+            <Typography
+              variant="caption"
+              color="success.main"
+              noWrap
+              sx={{ maxWidth: 300 }}
+            >
+              {savedPath}
+            </Typography>
+          </Box>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ImageThumbnail.tsx
+++ b/src/peanut-vision-ui/src/components/ImageThumbnail.tsx
@@ -1,0 +1,74 @@
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import CloseIcon from "@mui/icons-material/Close";
+import type { CapturedImage } from "../api/types";
+import { formatTime } from "../utils/formatTimestamp";
+
+/** Renders a single image thumbnail with selection highlight and delete button. */
+interface Props {
+  image: CapturedImage;
+  selected: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function ImageThumbnail({ image, selected, onSelect, onDelete }: Props) {
+  return (
+    <Box
+      onClick={() => onSelect(image.id)}
+      sx={{
+        flexShrink: 0,
+        cursor: "pointer",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 0.5,
+      }}
+    >
+      <Box
+        sx={{
+          position: "relative",
+          width: 80,
+          height: 60,
+          border: "2px solid",
+          borderColor: selected ? "primary.main" : "divider",
+          borderRadius: 1,
+          overflow: "hidden",
+          transition: "border-color 0.15s",
+          "&:hover .delete-btn": { opacity: 1 },
+        }}
+      >
+        <img
+          src={image.url}
+          alt={`Capture at ${formatTime(image.capturedAt)}`}
+          style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+        />
+        <IconButton
+          className="delete-btn"
+          size="small"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(image.id);
+          }}
+          sx={{
+            position: "absolute",
+            top: -2,
+            right: -2,
+            opacity: 0,
+            transition: "opacity 0.15s",
+            p: 0.25,
+            bgcolor: "rgba(0,0,0,0.6)",
+            color: "white",
+            "&:hover": { bgcolor: "error.main" },
+          }}
+        >
+          <CloseIcon sx={{ fontSize: 14 }} />
+        </IconButton>
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.65rem" }}>
+        {formatTime(image.capturedAt)}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/peanut-vision-ui/src/components/ImageViewer.tsx
+++ b/src/peanut-vision-ui/src/components/ImageViewer.tsx
@@ -1,10 +1,7 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import DownloadIcon from "@mui/icons-material/Download";
-import SaveIcon from "@mui/icons-material/Save";
+import ImageActionBar from "./ImageActionBar";
 
 interface Props {
   url: string | null;
@@ -21,21 +18,20 @@ export default function ImageViewer({ url, filename, errorMessage, savedPath }: 
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          height: 300,
+          height: "100%",
+          minHeight: 200,
           border: "1px dashed",
           borderColor: "divider",
           borderRadius: 1,
         }}
       >
-        <Typography color="text.secondary">
-          No captured frame
-        </Typography>
+        <Typography color="text.secondary">No captured frame</Typography>
       </Box>
     );
   }
 
   return (
-    <Box>
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", gap: 1 }}>
       <Box
         sx={{
           position: "relative",
@@ -43,13 +39,18 @@ export default function ImageViewer({ url, filename, errorMessage, savedPath }: 
           borderColor: "divider",
           borderRadius: 1,
           overflow: "hidden",
-          mb: 1,
+          flexGrow: 1,
+          minHeight: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          bgcolor: "background.default",
         }}
       >
         <img
           src={url}
           alt="Captured frame"
-          style={{ width: "100%", display: "block" }}
+          style={{ maxWidth: "100%", maxHeight: "100%", display: "block", objectFit: "contain" }}
         />
         {errorMessage && (
           <Box sx={{ position: "absolute", top: 8, left: 8 }}>
@@ -62,30 +63,8 @@ export default function ImageViewer({ url, filename, errorMessage, savedPath }: 
           </Box>
         )}
       </Box>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-        <Button
-          size="small"
-          startIcon={<DownloadIcon />}
-          href={url}
-          download={filename ?? `capture-${Date.now()}.png`}
-        >
-          Download
-        </Button>
-        {savedPath && (
-          <Tooltip title={savedPath}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0 }}>
-              <SaveIcon sx={{ fontSize: 14, color: "success.main", flexShrink: 0 }} />
-              <Typography
-                variant="caption"
-                color="success.main"
-                noWrap
-                sx={{ maxWidth: 300 }}
-              >
-                {savedPath}
-              </Typography>
-            </Box>
-          </Tooltip>
-        )}
+      <Box sx={{ flexShrink: 0 }}>
+        <ImageActionBar url={url} filename={filename} savedPath={savedPath} />
       </Box>
     </Box>
   );

--- a/src/peanut-vision-ui/src/hooks/useImageExport.ts
+++ b/src/peanut-vision-ui/src/hooks/useImageExport.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+import type { CapturedImage } from "../api/types";
+import { formatCaptureFilename } from "../utils/formatTimestamp";
+
+/** Encapsulates ZIP export logic for a collection of captured images. */
+export function useImageExport(images: CapturedImage[]) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExportZip = async () => {
+    if (images.length === 0) return;
+    setExporting(true);
+    try {
+      const zip = new JSZip();
+      for (let i = 0; i < images.length; i++) {
+        const image = images[i];
+        zip.file(formatCaptureFilename(image.capturedAt, i + 1), image.blob);
+      }
+      const blob = await zip.generateAsync({ type: "blob" });
+      saveAs(blob, `captures_${new Date().toISOString().slice(0, 10)}.zip`);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return { exporting, handleExportZip };
+}

--- a/src/peanut-vision-ui/src/hooks/useResizablePanel.ts
+++ b/src/peanut-vision-ui/src/hooks/useResizablePanel.ts
@@ -1,0 +1,55 @@
+import { useCallback, useRef } from "react";
+
+/** Options for configuring a horizontally resizable panel. */
+interface ResizablePanelOptions {
+  defaultWidth: number;
+  min: number;
+  max: number;
+  /** "right" = panel is on the right (drag handle on left edge); "left" = panel is on the left (drag handle on right edge). Default: "right" */
+  direction?: "left" | "right";
+}
+
+/** Encapsulates drag-resize logic for a panel, using refs to avoid re-renders during dragging. */
+export function useResizablePanel(options: ResizablePanelOptions) {
+  const { defaultWidth, min, max, direction = "right" } = options;
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelWidth = useRef(defaultWidth);
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(0);
+
+  const onResizerMouseDown = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    isDragging.current = true;
+    dragStartX.current = event.clientX;
+    dragStartWidth.current = panelWidth.current;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      if (!isDragging.current) return;
+      const delta = direction === "left"
+        ? moveEvent.clientX - dragStartX.current
+        : dragStartX.current - moveEvent.clientX;
+      const nextWidth = Math.min(max, Math.max(min, dragStartWidth.current + delta));
+      panelWidth.current = nextWidth;
+      if (panelRef.current) {
+        panelRef.current.style.width = `${nextWidth}px`;
+      }
+    };
+
+    const onMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [min, max, direction]);
+
+  return { panelRef, onResizerMouseDown, defaultWidth };
+}

--- a/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
+++ b/src/peanut-vision-ui/src/tabs/AcquisitionTab.tsx
@@ -1,42 +1,31 @@
-import { useCallback, useRef } from "react";
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import Typography from "@mui/material/Typography";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
 import ErrorAlert from "../components/ErrorAlert";
 import AcquisitionControls from "../components/AcquisitionControls";
-import AcquisitionStats from "../components/AcquisitionStats";
 import EventLog from "../components/EventLog";
-import ImageViewer from "../components/ImageViewer";
 import CapturedImageList from "../components/CapturedImageList";
+import DetailImageViewDialog from "../components/DetailImageViewDialog";
 import ContinuousSettings from "../components/ContinuousSettings";
 import ImageSaveSettingsPanel from "../components/ImageSaveSettingsPanel";
 import SessionSelector from "../components/SessionSelector";
-import HistogramChart from "../components/HistogramChart";
 import PresetSelector from "../components/PresetSelector";
 import CalibrationActions from "../components/CalibrationActions";
 import ExposureControl from "../components/ExposureControl";
-import SidebarSection from "../components/SidebarSection";
+import ImageViewer from "../components/ImageViewer";
 import CollapsiblePanel from "../components/CollapsiblePanel";
 import { useImageBuffer } from "../hooks/useImageBuffer";
 import { useAcquisitionActions } from "../hooks/useAcquisitionActions";
+import { useResizablePanel } from "../hooks/useResizablePanel";
+import { formatFilenameTimestamp } from "../utils/formatTimestamp";
 import { MAX_CAPTURED_IMAGES } from "../constants";
-
-function formatFilenameTimestamp(d: Date): string {
-  return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}_${String(d.getHours()).padStart(2, "0")}${String(d.getMinutes()).padStart(2, "0")}${String(d.getSeconds()).padStart(2, "0")}_${String(d.getMilliseconds()).padStart(3, "0")}`;
-}
 
 interface Props {
   onSessionChange?: (name: string | null) => void;
 }
-
-const RIGHT_PANEL_MIN = 200;
-const RIGHT_PANEL_MAX = 560;
-const RIGHT_PANEL_DEFAULT = 280;
 
 export default function AcquisitionTab({ onSessionChange }: Props = {}) {
   const { capturedFrames, selectedFrameId, addFrame, deleteFrame, clearAllFrames, selectFrame } =
@@ -44,42 +33,22 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
 
   const acq = useAcquisitionActions({ onFrameCaptured: addFrame });
 
-  // Right panel resize — width stored in a ref and applied via DOM ref
-  // to avoid re-renders during dragging
-  const rightPanelRef = useRef<HTMLDivElement>(null);
-  const rightPanelWidth = useRef(RIGHT_PANEL_DEFAULT);
-  const isDragging = useRef(false);
-  const dragStartX = useRef(0);
-  const dragStartWidth = useRef(0);
+  const { panelRef: sidebarRef, onResizerMouseDown: onSidebarResizerMouseDown } = useResizablePanel({
+    defaultWidth: 340,
+    min: 260,
+    max: 480,
+    direction: "left",
+  });
 
-  const onResizerMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    isDragging.current = true;
-    dragStartX.current = e.clientX;
-    dragStartWidth.current = rightPanelWidth.current;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
+  const { panelRef: rightPanelRef, onResizerMouseDown: onRightResizerMouseDown } = useResizablePanel({
+    defaultWidth: 280,
+    min: 200,
+    max: 560,
+  });
 
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!isDragging.current) return;
-      const delta = dragStartX.current - ev.clientX;
-      const next = Math.min(RIGHT_PANEL_MAX, Math.max(RIGHT_PANEL_MIN, dragStartWidth.current + delta));
-      rightPanelWidth.current = next;
-      if (rightPanelRef.current) rightPanelRef.current.style.width = `${next}px`;
-    };
-
-    const onMouseUp = () => {
-      isDragging.current = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-    };
-
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, []);
-
+  const [sidebarTab, setSidebarTab] = useState(0);
+  const [dialogImageId, setDialogImageId] = useState<string | null>(null);
+  const dialogImage = capturedFrames.find((f) => f.id === dialogImageId) ?? null;
   const selectedFrame = capturedFrames.find((f) => f.id === selectedFrameId) ?? null;
 
   return (
@@ -88,6 +57,7 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
 
       {/* LEFT SIDEBAR */}
       <Box
+        ref={sidebarRef}
         sx={{
           width: 340,
           flexShrink: 0,
@@ -97,10 +67,30 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
           p: 3,
           display: "flex",
           flexDirection: "column",
-          gap: 2,
         }}
       >
-        <SidebarSection label="Acquisition">
+        {/* Sticky tab header — bleeds past p:3 with mx:-3 */}
+        <Box
+          sx={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            bgcolor: "background.paper",
+            mx: -3,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            mb: 2,
+          }}
+        >
+          <Tabs value={sidebarTab} onChange={(_, v) => setSidebarTab(v)} variant="fullWidth">
+            <Tab label="Capture" />
+            <Tab label="Camera" />
+            <Tab label="Settings" />
+          </Tabs>
+        </Box>
+
+        {/* Tab 0: Capture */}
+        <Box sx={{ display: sidebarTab === 0 ? "flex" : "none", flexDirection: "column", gap: 2 }}>
           <PresetSelector
             profileId={acq.selectedProfile}
             triggerMode={acq.triggerMode}
@@ -140,9 +130,10 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
               disabled={acq.acquisitionStatus?.isActive}
             />
           )}
-        </SidebarSection>
+        </Box>
 
-        <SidebarSection label="Exposure">
+        {/* Tab 1: Camera */}
+        <Box sx={{ display: sidebarTab === 1 ? "flex" : "none", flexDirection: "column", gap: 2 }}>
           <ExposureControl
             exposure={acq.exposure}
             exposureValue={acq.exposureValue}
@@ -153,9 +144,6 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
             onLoad={acq.handleLoadExposure}
             onApply={acq.handleApplyExposure}
           />
-        </SidebarSection>
-
-        <SidebarSection label="Calibration">
           <CalibrationActions
             busy={acq.busy}
             ffcEnabled={acq.ffcEnabled}
@@ -164,47 +152,59 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
             onWhiteBalance={acq.handleWhiteBalance}
             onFfcToggle={acq.handleFfcToggle}
           />
-        </SidebarSection>
+        </Box>
 
-        <Accordion disableGutters elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography variant="subtitle2">Save Settings</Typography>
-          </AccordionSummary>
-          <AccordionDetails sx={{ p: 1 }}>
-            <ImageSaveSettingsPanel />
-          </AccordionDetails>
-        </Accordion>
-
-        <SidebarSection label="Session">
+        {/* Tab 2: Settings */}
+        <Box sx={{ display: sidebarTab === 2 ? "flex" : "none", flexDirection: "column", gap: 2 }}>
+          <ImageSaveSettingsPanel />
           <SessionSelector onSessionChange={onSessionChange} />
-        </SidebarSection>
-      </Box>
-
-      {/* MAIN CANVAS */}
-      <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Box sx={{ flexGrow: 1, p: 2, display: "flex", flexDirection: "column", gap: 2, overflow: "hidden" }}>
-          <Box sx={{ flexGrow: 1, minHeight: 0 }}>
-            <ImageViewer
-              url={selectedFrame?.url ?? null}
-              filename={selectedFrame ? `capture-${formatFilenameTimestamp(selectedFrame.capturedAt)}.png` : undefined}
-              errorMessage={acq.acquisitionStatus?.lastError}
-              savedPath={selectedFrame?.savedPath}
-            />
-          </Box>
-          <Box sx={{ display: "flex", gap: 2, flexShrink: 0 }}>
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <HistogramChart />
-            </Box>
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <AcquisitionStats stats={acq.acquisitionStatus?.statistics} />
-            </Box>
-          </Box>
         </Box>
       </Box>
 
-      {/* DRAG HANDLE */}
+      {/* LEFT SIDEBAR DRAG HANDLE */}
       <Box
-        onMouseDown={onResizerMouseDown}
+        onMouseDown={onSidebarResizerMouseDown}
+        sx={{
+          width: 4,
+          flexShrink: 0,
+          cursor: "col-resize",
+          bgcolor: "divider",
+          transition: "background-color 0.15s",
+          "&:hover": { bgcolor: "primary.main" },
+        }}
+      />
+
+      {/* MAIN CANVAS */}
+      <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Box sx={{ flexGrow: 1, minHeight: 0, p: 1.5, display: "flex", flexDirection: "column" }}>
+          <ImageViewer
+            url={selectedFrame?.url ?? null}
+            filename={
+              selectedFrame
+                ? `capture_${formatFilenameTimestamp(selectedFrame.capturedAt)}.png`
+                : undefined
+            }
+            errorMessage={acq.acquisitionStatus?.lastError}
+            savedPath={selectedFrame?.savedPath}
+          />
+        </Box>
+        <Box sx={{ flexShrink: 0, p: 1.5, pt: 0 }}>
+          <CapturedImageList
+            images={capturedFrames}
+            selectedId={selectedFrameId}
+            onSelect={(id) => {
+              selectFrame(id);
+              setDialogImageId(id);
+            }}
+            onDelete={deleteFrame}
+            onClear={clearAllFrames}
+          />
+        </Box>
+      </Box>
+
+      {/* RIGHT PANEL DRAG HANDLE */}
+      <Box
+        onMouseDown={onRightResizerMouseDown}
         sx={{
           width: 4,
           flexShrink: 0,
@@ -219,27 +219,23 @@ export default function AcquisitionTab({ onSessionChange }: Props = {}) {
       <Box
         ref={rightPanelRef}
         sx={{
-          width: RIGHT_PANEL_DEFAULT,
+          width: 280,
           flexShrink: 0,
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
         }}
       >
-        <CollapsiblePanel label="Captures" count={capturedFrames.length} defaultOpen>
-          <CapturedImageList
-            images={capturedFrames}
-            selectedId={selectedFrameId}
-            onSelect={selectFrame}
-            onDelete={deleteFrame}
-            onClear={clearAllFrames}
-          />
-        </CollapsiblePanel>
-
         <CollapsiblePanel label="Event Log" defaultOpen={false}>
           <EventLog events={acq.acquisitionStatus?.recentEvents} />
         </CollapsiblePanel>
       </Box>
+
+      <DetailImageViewDialog
+        image={dialogImage}
+        errorMessage={acq.acquisitionStatus?.lastError}
+        onClose={() => setDialogImageId(null)}
+      />
 
       <Snackbar
         open={acq.snackbar !== null}

--- a/src/peanut-vision-ui/src/utils/formatTimestamp.ts
+++ b/src/peanut-vision-ui/src/utils/formatTimestamp.ts
@@ -1,0 +1,29 @@
+/** Formats a Date as "HH:MM:SS" for display purposes. */
+export function formatTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+/** Formats a Date as "YYYYMMDD_HHmmss_SSS" for use in filenames. */
+export function formatFilenameTimestamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  const millis = String(date.getMilliseconds()).padStart(3, "0");
+  return `${year}${month}${day}_${hours}${minutes}${seconds}_${millis}`;
+}
+
+/** Formats a Date and sequence index as a capture filename for ZIP export. */
+export function formatCaptureFilename(date: Date, index: number): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const time = formatTime(date).replace(/:/g, "");
+  const sequence = String(index).padStart(3, "0");
+  return `capture_${year}${month}${day}_${time}_${sequence}.png`;
+}


### PR DESCRIPTION
## Summary

- **Tab-based sidebar**: Replaces 5 stacked scroll-heavy sections with 3 MUI Tabs (Capture / Camera / Settings). Tab panels use `display:none` (not unmount) to preserve component state across switches. Sticky tab header bleeds edge-to-edge past sidebar padding.
- **ImageViewer restored to main canvas**: Large selected-frame preview sits above the thumbnail strip in a flex-column layout (ImageViewer grows, CapturedImageList is fixed-height strip). `DetailImageViewDialog` still opens on thumbnail click.
- **Resizable left sidebar**: Extends `useResizablePanel` with a `direction` option — `"left"` flips the delta sign so dragging the right-edge handle correctly widens the sidebar (260–480px, default 340px).
- **Component decomposition** (previously uncommitted from last session): `AcquisitionControls`, `CapturedImageList`, `ImageViewer` split into focused sub-components (`AcquisitionActionBar`, `AcquisitionModeSelector`, `CameraProfileSelector`, `ImageThumbnail`, `ImageActionBar`, `DetailImageViewDialog`). Adds `useImageExport` hook and `formatTimestamp` utils.

## Test plan

- [ ] Acquisition tab loads without errors
- [ ] All 3 sidebar tabs render correct components (Capture / Camera / Settings)
- [ ] Switching tabs does not reset form state (e.g. exposure slider stays put)
- [ ] Main canvas shows selected frame preview; clicking another thumbnail updates it
- [ ] `DetailImageViewDialog` opens on thumbnail click
- [ ] Left sidebar resizes by dragging its right edge (260–480px)
- [ ] Right panel resize still works as before
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)