### PR TITLE
feat: global toast foundation — ToastContext + ToastContainer

### DIFF
--- a/src/peanut-vision-ui/src/components/ToastContainer.tsx
+++ b/src/peanut-vision-ui/src/components/ToastContainer.tsx
@@ -1,0 +1,46 @@
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Collapse from "@mui/material/Collapse";
+import Portal from "@mui/material/Portal";
+import Slide from "@mui/material/Slide";
+import { TransitionGroup } from "react-transition-group";
+import { useToast } from "../contexts/ToastContext";
+
+export default function ToastContainer() {
+  const { toasts, dismiss } = useToast();
+
+  return (
+    <Portal>
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+          zIndex: "snackbar",
+          width: 360,
+          maxWidth: "calc(100vw - 48px)",
+          pointerEvents: "none",
+        }}
+      >
+        <TransitionGroup component={null}>
+          {toasts.map((t) => (
+            <Collapse key={t.id} timeout={250}>
+              <Box sx={{ mb: 1, pointerEvents: "all" }}>
+                <Slide in direction="left" timeout={200}>
+                  <Alert
+                    severity={t.severity}
+                    variant="filled"
+                    onClose={() => dismiss(t.id)}
+                    sx={{ width: "100%", boxShadow: 3, alignItems: "center" }}
+                  >
+                    {t.message}
+                  </Alert>
+                </Slide>
+              </Box>
+            </Collapse>
+          ))}
+        </TransitionGroup>
+      </Box>
+    </Portal>
+  );
+}

--- a/src/peanut-vision-ui/src/contexts/ToastContext.tsx
+++ b/src/peanut-vision-ui/src/contexts/ToastContext.tsx
@@ -1,0 +1,70 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import ToastContainer from "../components/ToastContainer";
+
+type ToastSeverity = "success" | "info" | "warning" | "error";
+
+export interface Toast {
+  id: string;
+  message: string;
+  severity: ToastSeverity;
+  duration: number | null;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  toast: (message: string, severity?: ToastSeverity, duration?: number | null) => void;
+  dismiss: (id: string) => void;
+}
+
+const DEFAULT_DURATION: Record<ToastSeverity, number | null> = {
+  success: 3000,
+  info: 3000,
+  warning: 5000,
+  error: null,
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (message: string, severity: ToastSeverity = "info", duration?: number | null) => {
+      const id = crypto.randomUUID();
+      const resolved = duration !== undefined ? duration : DEFAULT_DURATION[severity];
+
+      setToasts((prev) => {
+        const next = [...prev, { id, message, severity, duration: resolved }];
+        return next.length > 5 ? next.slice(next.length - 5) : next;
+      });
+
+      if (resolved !== null && resolved > 0) {
+        setTimeout(() => dismiss(id), resolved);
+      }
+    },
+    [dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast, dismiss }}>
+      {children}
+      <ToastContainer />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside <ToastProvider>");
+  return ctx;
+}

--- a/src/peanut-vision-ui/src/main.tsx
+++ b/src/peanut-vision-ui/src/main.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import theme from "./theme";
 import App from "./App";
+import { ToastProvider } from "./contexts/ToastContext";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,7 +21,9 @@ createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <App />
+        <ToastProvider>
+          <App />
+        </ToastProvider>
       </ThemeProvider>
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary

- **`ToastContext.tsx`**: React context with `ToastProvider` and `useToast` hook. Manages a capped stack of up to 5 toasts with severity-based auto-dismiss durations (`success`/`info` → 3s, `warning` → 5s, `error` → persistent).
- **`ToastContainer.tsx`**: Renders toasts into a `Portal` to escape overflow clipping, stacked bottom-right with MUI `Slide` (entry) + `Collapse` (add/remove) animations via `react-transition-group`.
- **`main.tsx`**: Wraps `<App />` with `<ToastProvider>` inside `<ThemeProvider>` so the toast system is globally available.

## Design decisions

- **`Portal` rendering**: avoids z-index/overflow clipping issues from deeply nested layout containers.
- **Severity-based durations**: errors are persistent by default (require manual close); warnings linger longer than informational toasts.
- **Max 5 toasts**: oldest are dropped when the cap is exceeded to prevent unbounded stacking.
- **`useToast` guard**: throws at render time if called outside `<ToastProvider>`, catching misconfiguration early.

## Test plan

- [ ] Verify `npm run build` passes with no TypeScript errors
- [ ] Confirm `useToast().toast(...)` displays a toast in the bottom-right corner
- [ ] Confirm `error` severity toasts do not auto-dismiss; others dismiss after their configured duration
- [ ] Confirm close button on each toast calls `dismiss(id)` and removes it with animation
- [ ] Confirm more than 5 simultaneous toasts truncates the oldest entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)