### PR TITLE
fix: route frontend API calls through Vite proxy for external access

### DIFF
--- a/src/peanut-vision-app/src/constants.ts
+++ b/src/peanut-vision-app/src/constants.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'http://localhost:5000/api'
+export const API_BASE_URL = '/api'
 export const POLL_INTERVAL_MS = 3000
 export const REFRESH_THROTTLE_MS = 3000
 export const DEFAULT_EXPOSURE_MIN = 100

--- a/src/peanut-vision-app/vite.config.ts
+++ b/src/peanut-vision-app/vite.config.ts
@@ -14,6 +14,18 @@ const config = defineConfig({
     tanstackRouter({ target: 'react', autoCodeSplitting: true }),
     viteReact(),
   ],
+  server: {
+    host: true,            // bind 0.0.0.0 so external clients (e.g. ngrok) can reach the dev server
+    allowedHosts: true,    // accept ngrok / arbitrary forwarded host headers
+    proxy: {
+      // Forward API + SSE calls to the backend so the browser talks to a single origin.
+      // localhost:5000 is resolved here (on the dev machine), not in the remote browser.
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Problem

When the Vite dev server was exposed externally (e.g. via ngrok), every API call from the frontend failed. Loading the app over the ngrok URL worked, but no data ever loaded.

## Root Cause

The frontend hardcoded `API_BASE_URL = 'http://localhost:5000/api'`. This string runs in the **client browser**, so for an external visitor `localhost:5000` resolves to *their own* machine — not the dev host — where no API server exists. The Vite config also had no proxy, so there was no single-origin path to the backend.

```mermaid
graph LR
    subgraph remote["Remote visitor's PC"]
        B["Browser"]
        RL["localhost:5000<br/>(nothing here)"]
    end
    subgraph dev["Dev machine"]
        V["Vite :5173"]
        API["API :5000"]
    end
    B -->|"1. load app (ngrok tunnel)"| V
    B -.->|"2. fetch localhost:5000/api"| RL
    RL -.->|"FAIL"| B
```

After: the browser calls the relative `/api` on its own origin, and Vite proxies to the backend — so `localhost` is resolved on the dev machine.

```mermaid
graph LR
    subgraph remote["Remote visitor's PC"]
        B["Browser"]
    end
    subgraph dev["Dev machine"]
        V["Vite :5173<br/>proxy /api"]
        API["API :5000"]
    end
    B -->|"fetch /api (same origin, ngrok tunnel)"| V
    V -->|"proxy to localhost:5000"| API
    API -->|"OK"| B
```

## Frontend Changes

| File | Change |
|------|--------|
| `src/constants.ts` | `API_BASE_URL` changed from absolute `http://localhost:5000/api` to relative `/api` |
| `vite.config.ts` | Added dev-server `proxy` for `/api` → `http://localhost:5000`, plus `host: true` and `allowedHosts: true` for forwarded-host access |

All API consumers (`fetch`, `EventSource` SSE, `<img src>`) build URLs from `API_BASE_URL`, so they resolve against the page origin with no further changes.

## Test Plan

- [x] `vitest run` — 47 tests passed
- [x] `tsc --noEmit` — no type errors
- [ ] Run `vite` dev server (restart required), expose via ngrok, confirm API calls and live preview SSE work from an external browser
- [ ] Confirm local access via `localhost:5173` still works