### PR TITLE
fix: allow editing presets after their CamFile is renamed

### DIFF
--- a/src/PeanutVision.Api.Tests/Tests/Acquisition/AcquisitionConfigPresetTests.cs
+++ b/src/PeanutVision.Api.Tests/Tests/Acquisition/AcquisitionConfigPresetTests.cs
@@ -1,16 +1,20 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using PeanutVision.Api.Services;
 using PeanutVision.Api.Tests.Infrastructure;
 
 namespace PeanutVision.Api.Tests.Tests.Acquisition;
 
 public class AcquisitionConfigPresetTests : IClassFixture<PeanutVisionApiFactory>, IAsyncLifetime
 {
+    private readonly PeanutVisionApiFactory _factory;
     private readonly HttpClient _client;
     private readonly string _testPresetName = $"test-preset-{Guid.NewGuid():N}";
 
     public AcquisitionConfigPresetTests(PeanutVisionApiFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
     }
 
@@ -77,6 +81,37 @@ public class AcquisitionConfigPresetTests : IClassFixture<PeanutVisionApiFactory
         });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_preset_keeps_stale_profileId_after_camfile_renamed()
+    {
+        // A preset was saved while its cam file existed; the cam file was later
+        // renamed, leaving the stored profileId "stale". Seed it directly through
+        // the service to bypass create-time validation, simulating the post-rename
+        // state of an already-persisted preset.
+        var presets = _factory.Services.GetRequiredService<IAcquisitionConfigPresetService>();
+        await presets.SaveAsync(new AcquisitionConfigPreset
+        {
+            Name = _testPresetName,
+            ProfileId = "renamed-away.cam",
+            FrameCount = 1,
+        });
+
+        // Editing other fields while keeping the now-stale profileId must succeed
+        // (the profileId is grandfathered because an existing preset already uses it).
+        var response = await _client.PutJsonAsync("/api/presets", new
+        {
+            name = _testPresetName,
+            profileId = "renamed-away.cam",
+            frameCount = 42,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var getResp = await _client.GetAsync($"/api/presets/{Uri.EscapeDataString(_testPresetName)}");
+        using var doc = JsonDocument.Parse(await getResp.Content.ReadAsStringAsync());
+        Assert.Equal(42, doc.RootElement.GetProperty("frameCount").GetInt32());
     }
 
     [Fact]

--- a/src/PeanutVision.Api.Tests/Tests/System/SystemCamerasTests.cs
+++ b/src/PeanutVision.Api.Tests/Tests/System/SystemCamerasTests.cs
@@ -45,7 +45,7 @@ public class SystemCamerasTests : IClassFixture<PeanutVisionApiFactory>, IAsyncL
         using var doc = await response.ReadJsonDocumentAsync();
         foreach (var entry in doc.RootElement.EnumerateArray())
         {
-            Assert.Equal(System.Text.Json.JsonValueKind.String, entry.ValueKind);
+            Assert.Equal(JsonValueKind.String, entry.ValueKind);
             Assert.EndsWith(".cam", entry.GetString(), StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/src/PeanutVision.Api/Controllers/PresetController.cs
+++ b/src/PeanutVision.Api/Controllers/PresetController.cs
@@ -35,12 +35,18 @@ public class PresetController : ControllerBase
             return BadRequest(new { error = "Preset name is required" });
         if (string.IsNullOrWhiteSpace(preset.ProfileId))
             return BadRequest(new { error = "ProfileId is required" });
-        if (!_camFileService.TryGetByFileName(preset.ProfileId, out _))
+        // A new profileId must reference a known cam file, but an existing preset
+        // whose cam file was renamed afterward is grandfathered in so its other
+        // fields stay editable (the profileId is already persisted on a preset).
+        if (!_camFileService.TryGetByFileName(preset.ProfileId, out _) && !IsProfileIdUsedByExistingPreset(preset.ProfileId))
             return BadRequest(new { error = $"Camera profile '{preset.ProfileId}' not found." });
 
         await _presets.SaveAsync(preset);
         return Ok(preset);
     }
+
+    private bool IsProfileIdUsedByExistingPreset(string profileId)
+        => _presets.GetAll().Any(p => string.Equals(p.ProfileId, profileId, StringComparison.OrdinalIgnoreCase));
 
     [HttpDelete("{name}")]
     public async Task<ActionResult> Delete(string name)

--- a/src/peanut-vision-app/src/components/Acquisition/CaptureTab.tsx
+++ b/src/peanut-vision-app/src/components/Acquisition/CaptureTab.tsx
@@ -486,9 +486,14 @@ function PresetTab({
               >
                 {camerasLoading
                   ? <option>로딩 중…</option>
-                  : cameras.map((name) => (
-                      <option key={name} value={name}>{name}</option>
-                    ))
+                  : <>
+                      {editState.profileId && !cameras.includes(editState.profileId) && (
+                        <option value={editState.profileId}>{editState.profileId} (사용 불가)</option>
+                      )}
+                      {cameras.map((name) => (
+                        <option key={name} value={name}>{name}</option>
+                      ))}
+                    </>
                 }
               </select>
             </label>

--- a/src/peanut-vision-app/src/components/shared/AcquisitionSettings/index.tsx
+++ b/src/peanut-vision-app/src/components/shared/AcquisitionSettings/index.tsx
@@ -87,9 +87,14 @@ export default function AcquisitionSettings({
           >
             {camerasLoading
               ? <option>로딩 중…</option>
-              : cameras.map((name) => (
-                  <option key={name} value={name}>{name}</option>
-                ))
+              : <>
+                  {config.profileId && !cameras.includes(config.profileId) && (
+                    <option value={config.profileId}>{config.profileId} (사용 불가)</option>
+                  )}
+                  {cameras.map((name) => (
+                    <option key={name} value={name}>{name}</option>
+                  ))}
+                </>
             }
           </select>
         </label>

--- a/src/peanut-vision-app/src/test/AcquisitionSettings.test.tsx
+++ b/src/peanut-vision-app/src/test/AcquisitionSettings.test.tsx
@@ -58,6 +58,19 @@ describe('Camera profile select', () => {
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'cam2.cam' } })
     expect(onChange).toHaveBeenCalledWith('profileId', 'cam2.cam')
   })
+
+  it('keeps a stale profileId selectable when it is no longer in the cameras list', () => {
+    // CamFile was renamed after this profile was saved; the controlled select
+    // must still reflect the saved value instead of silently falling back to
+    // the first camera (which would be sent to the server on save).
+    renderSettings({
+      config: { ...BASE_CONFIG, profileId: 'renamed-away.cam' },
+      cameras: ['cam1.cam', 'cam2.cam'],
+    })
+    const combo = screen.getByRole('combobox') as HTMLSelectElement
+    expect(combo.value).toBe('renamed-away.cam')
+    expect(screen.getByRole('option', { name: /renamed-away\.cam/ })).toBeInTheDocument()
+  })
 })
 
 // ── Format radio ──

--- a/src/peanut-vision-app/src/test/CaptureTab.test.tsx
+++ b/src/peanut-vision-app/src/test/CaptureTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import CaptureTab from '@/components/Acquisition/CaptureTab'
 import { renderWithProviders } from './helpers'
 import type { AcquisitionConfigPreset } from '@/api/types'
@@ -100,5 +100,23 @@ describe('CaptureTab — preset list stale profile warning', () => {
     await waitFor(() => screen.getByText('valid preset'))
 
     expect(screen.queryByTestId('stale-profile-warning-valid preset')).toBeNull()
+  })
+
+  it('edit dialog keeps the stale profileId selected instead of silently resetting it', async () => {
+    renderWithProviders(
+      <CaptureTab acqConfig={makeAcqConfig()} session={makeSession()} />
+    )
+
+    const presetTabBtn = await screen.findByRole('button', { name: /저장된 설정/i })
+    presetTabBtn.click()
+
+    await waitFor(() => screen.getByText('stale preset'))
+
+    // Open the edit dialog for the stale preset (second preset in the list).
+    fireEvent.click(screen.getAllByTitle('수정')[1])
+
+    const combo = await screen.findByRole('combobox') as HTMLSelectElement
+    expect(combo.value).toBe('deleted-cam.cam')
+    expect(screen.getByRole('option', { name: /deleted-cam\.cam/ })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem

A saved acquisition preset stores its camera as `profileId`, which is literally the `.cam` filename. The set of valid `profileId`s is scanned from the CamFiles directory at startup. When a `.cam` file is renamed, every preset that referenced the old name becomes orphaned — and the preset can no longer be edited at all. Changing unrelated fields (name, format, interval, frame count) fails, so the saved configuration is effectively stuck.

## Root Cause

Two layers each reject the stale value, and the frontend hides the problem until save:

```mermaid
flowchart LR
    R["CamFile renamed"] --> S["Preset profileId<br/>now 'stale'"]
    S --> FE["Edit dialog select<br/>lists current cameras only"]
    FE --> M["Controlled select shows<br/>first option, but React<br/>state keeps stale value"]
    M --> PUT["Save sends stale profileId"]
    PUT --> BE["PresetController.Save:<br/>TryGetByFileName fails -> 400"]
```

- **BE:** `PresetController.Save` rejected any `profileId` not currently present on disk, so even editing other fields of a stale preset returned `400 Bad Request`.
- **FE:** The camera-profile `<select>` was populated only from the current cameras list. A stale `profileId` is not among the options, so the controlled select silently rendered the first option in the DOM while React state still held the stale value. Saving then transmitted the stale value, which the backend rejected.

## Backend Changes

| File / Class | Change |
|---|---|
| `Controllers/PresetController.cs` | Grandfather a `profileId` that is already used by an existing saved preset, so stale presets stay editable; brand-new presets still require a valid camera. |

## Frontend Changes

| File / Component | Change |
|---|---|
| `components/shared/AcquisitionSettings/index.tsx` | When the current `profileId` is not in `cameras`, render it as a `(사용 불가)` option so the controlled select reflects the true value. |
| `components/Acquisition/CaptureTab.tsx` | Same stale-option handling in the preset edit-dialog select. |

## Other

Fixed a pre-existing compile error in `SystemCamerasTests` where the fully-qualified `System.Text.Json` bound `System` to the nested `...Tests.System` namespace, which broke the entire API test project build.

## Test Plan

- [x] BE regression `Update_preset_keeps_stale_profileId_after_camfile_renamed` (seeds a stale preset, asserts edit returns 200)
- [x] Existing BE guard `Save_preset_with_unknown_profileId_returns_bad_request` still passes (new presets must use a valid camera)
- [x] FE regressions: settings select and edit-dialog select both keep a stale `profileId` selected instead of resetting to the first camera
- [x] Full backend suite: 176 passing
- [x] Full frontend suite: 49 passing
- [ ] Manual: rename a `.cam` file, restart API, open an affected preset's edit dialog, confirm the old name shows as `(사용 불가)`, re-select a valid camera, and save successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)